### PR TITLE
slight golf for the golf (centroid decomp)

### DIFF
--- a/library/trees/centroid_decomp.hpp
+++ b/library/trees/centroid_decomp.hpp
@@ -7,7 +7,7 @@
 //! @space O(n)
 void centroid(auto& g, auto f) {
   vi siz(sz(g));
-  auto ctd = [&](auto&& ctd, int u, int p, int n) -> int {
+  auto ctd = [&](auto ctd, int u, int p, int n) -> int {
     siz[u] = 1;
     for (int v : g[u])
       if (v != p) {
@@ -16,7 +16,7 @@ void centroid(auto& g, auto f) {
       }
     return 2 * siz[u] >= n ? siz[p] = n - siz[u], u : -1;
   };
-  auto dfs = [&](auto&& dfs, int u, int p, int n) -> void {
+  auto dfs = [&](auto dfs, int u, int p, int n) -> void {
     f(u = ctd(ctd, u, u, n), p);
     for (int v : g[u])
       erase(g[v], u), dfs(dfs, v, u, siz[v]);


### PR DESCRIPTION
using a universal reference (`auto&&`) is unnecessary for recursive lambda parameters