### PR TITLE
re-pin cppcheck suppression to line number

### DIFF
--- a/tests/.config/.cppcheck_suppression_list
+++ b/tests/.config/.cppcheck_suppression_list
@@ -60,5 +60,5 @@ unusedFunction:../kactl/content/data-structures/UnionFind.h:14
 unusedFunction:../kactl/content/number-theory/ModPow.h:13
 unusedFunction:../kactl/stress-tests/utilities/genTree.h:49
 containerOutOfBounds:../library/data_structures_[l,r)/uncommon/permutation_tree.hpp:85
-ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/bit.hpp
+ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/bit.hpp:15
 ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/lazy_seg_tree.hpp:4


### PR DESCRIPTION
Restores the line-pinned convention for the one cppcheck suppression that lost it.

In #222 the `ctuOneDefinitionRuleViolation` suppression for `data_structures_[l,r)/bit.hpp` was made file-level as a quick fix after #220 shifted `struct BIT` from line 14 to 15, breaking the pinned entry. We've since decided file-level suppressions are undesirable (they hide the check for the whole file), so this re-pins the entry to the current line:

```
ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/bit.hpp:15
```

All other suppressions in the list were already line-pinned and are untouched. The related PR #224 (which would have made all suppressions file-level) has been closed.
