### PR TITLE
standardize tests: template macros, c++20 ranges, naming conventions

### DIFF
--- a/tests/.config/.cppcheck_suppression_list
+++ b/tests/.config/.cppcheck_suppression_list
@@ -60,10 +60,5 @@ unusedFunction:../kactl/content/data-structures/UnionFind.h:14
 unusedFunction:../kactl/content/number-theory/ModPow.h:13
 unusedFunction:../kactl/stress-tests/utilities/genTree.h:49
 containerOutOfBounds:../library/data_structures_[l,r)/uncommon/permutation_tree.hpp:85
-mismatchingContainerExpression:library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp:20
-mismatchingContainerExpression:library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp:13
-mismatchingContainerExpression:library_checker_aizu_tests/data_structures/mode_query.test.cpp:13
-mismatchingContainerExpression:library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp:13
-mismatchingContainerExpression:library_checker_aizu_tests/strings/single_matching_bs.test.cpp:73
 ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/bit.hpp:15
 ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/lazy_seg_tree.hpp:4

--- a/tests/.config/.cppcheck_suppression_list
+++ b/tests/.config/.cppcheck_suppression_list
@@ -60,5 +60,10 @@ unusedFunction:../kactl/content/data-structures/UnionFind.h:14
 unusedFunction:../kactl/content/number-theory/ModPow.h:13
 unusedFunction:../kactl/stress-tests/utilities/genTree.h:49
 containerOutOfBounds:../library/data_structures_[l,r)/uncommon/permutation_tree.hpp:85
+mismatchingContainerExpression:library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp:20
+mismatchingContainerExpression:library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp:13
+mismatchingContainerExpression:library_checker_aizu_tests/data_structures/mode_query.test.cpp:13
+mismatchingContainerExpression:library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp:13
+mismatchingContainerExpression:library_checker_aizu_tests/strings/single_matching_bs.test.cpp:73
 ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/bit.hpp:15
 ctuOneDefinitionRuleViolation:../library/data_structures_[l,r)/lazy_seg_tree.hpp:4

--- a/tests/library_checker_aizu_tests/cd_asserts.hpp
+++ b/tests/library_checker_aizu_tests/cd_asserts.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "../../library/trees/centroid_decomp.hpp"
-void cd_asserts(vector<vector<int>> adj) {
-  vector<int> decomp_size(sz(adj), -1);
-  vector<int> naive_par_decomp(sz(adj), -1);
+void cd_asserts(vector<vi> adj) {
+  vi decomp_size(sz(adj), -1);
+  vi naive_par_decomp(sz(adj), -1);
   vi par = cd(adj, [&](int cent) -> void {
     assert(decomp_size[cent] == -1);
     auto dfs = [&](auto&& self, int u, int p) -> int {

--- a/tests/library_checker_aizu_tests/compress_tree_asserts.hpp
+++ b/tests/library_checker_aizu_tests/compress_tree_asserts.hpp
@@ -5,23 +5,22 @@
 #undef RMQ
 #undef LCA
 #include "../../library/contest/random.hpp"
-void compress_tree_asserts(vector<vector<int>> adj,
-  LCA& lc_rm) {
+void compress_tree_asserts(vector<vi> adj, LCA& lc_rm) {
   int n = sz(adj);
-  vector<bool> used(n);
+  vector<bool> vis(n);
   KACTL_LCA kactl_lca(adj);
   {
     auto [parent, to_node] = lc_rm.compress_tree({});
     assert(empty(parent) && empty(to_node));
   }
-  for (int tests = 0; tests < 10; tests++) {
-    vector<int> subset;
+  rep(tests, 0, 10) {
+    vi subset;
     {
       int subset_size = rnd(1, min(n, 10));
       while (subset_size--) {
         int u = rnd(0, n - 1);
-        if (!used[u]) {
-          used[u] = 1;
+        if (!vis[u]) {
+          vis[u] = 1;
           subset.push_back(u);
         }
       }
@@ -30,13 +29,13 @@ void compress_tree_asserts(vector<vector<int>> adj,
     auto [lc_rm_parent, lc_rm_to_node] =
       lc_rm.compress_tree(subset);
     assert(sz(lc_rm_parent) == sz(kactl_res));
-    for (int i = 0; i < sz(lc_rm_parent); i++) {
+    rep(i, 0, sz(lc_rm_parent)) {
       assert(lc_rm_to_node[i] == kactl_res[i].second);
       assert(lc_rm_parent[i] < i);
       if (i > 0)
         assert(lc_rm_parent[i] == kactl_res[i].first);
       else assert(lc_rm_parent[i] == -1);
     }
-    for (int u : subset) used[u] = 0;
+    for (int u : subset) vis[u] = 0;
   }
 }

--- a/tests/library_checker_aizu_tests/convolution/gcd_convolution.test.cpp
+++ b/tests/library_checker_aizu_tests/convolution/gcd_convolution.test.cpp
@@ -2,15 +2,15 @@
   "https://judge.yosupo.jp/problem/gcd_convolution"
 #include "../template.hpp"
 #include "../../../library/convolution/gcd_convolution.hpp"
-istream& operator>>(istream& is, vector<int>& v) {
-  for (int i = 1; i < sz(v); i++) is >> v[i];
+istream& operator>>(istream& is, vi& v) {
+  rep(i, 1, sz(v)) is >> v[i];
   return is;
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n + 1), b(n + 1);
+  vi a(n + 1), b(n + 1);
   cin >> a >> b;
   auto c = gcd_convolution(a, b);
   for (int i = 1; i <= n; i++) cout << c[i] << ' ';

--- a/tests/library_checker_aizu_tests/convolution/lcm_convolution.test.cpp
+++ b/tests/library_checker_aizu_tests/convolution/lcm_convolution.test.cpp
@@ -2,15 +2,15 @@
   "https://judge.yosupo.jp/problem/lcm_convolution"
 #include "../template.hpp"
 #include "../../../library/convolution/lcm_convolution.hpp"
-istream& operator>>(istream& is, vector<int>& v) {
-  for (int i = 1; i < sz(v); i++) is >> v[i];
+istream& operator>>(istream& is, vi& v) {
+  rep(i, 1, sz(v)) is >> v[i];
   return is;
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n + 1), b(n + 1);
+  vi a(n + 1), b(n + 1);
   cin >> a >> b;
   auto c = lcm_convolution(a, b);
   for (int i = 1; i <= n; i++) cout << c[i] << ' ';

--- a/tests/library_checker_aizu_tests/convolution/min_plus_convolution.test.cpp
+++ b/tests/library_checker_aizu_tests/convolution/min_plus_convolution.test.cpp
@@ -2,7 +2,7 @@
   "https://judge.yosupo.jp/problem/min_plus_convolution_convex_arbitrary"
 #include "../template.hpp"
 #include "../../../library/convolution/min_plus_convolution_convex_and_arbitrary.hpp"
-istream& operator>>(istream& is, vector<int>& v) {
+istream& operator>>(istream& is, vi& v) {
   for (int& e : v) is >> e;
   return is;
 }
@@ -10,7 +10,7 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<int> convex(n), arbitrary(m);
+  vi convex(n), arbitrary(m);
   cin >> convex >> arbitrary;
   auto res = min_plus(convex, arbitrary);
   for (int r : res) cout << r << ' ';

--- a/tests/library_checker_aizu_tests/convolution/xor_convolution.test.cpp
+++ b/tests/library_checker_aizu_tests/convolution/xor_convolution.test.cpp
@@ -2,8 +2,8 @@
   "https://judge.yosupo.jp/problem/bitwise_xor_convolution"
 #include "../template.hpp"
 #include "../../../library/convolution/xor_convolution.hpp"
-istream& operator>>(istream& is, vector<int>& v) {
-  for (int i = 0; i < sz(v); i++) is >> v[i];
+istream& operator>>(istream& is, vi& v) {
+  rep(i, 0, sz(v)) is >> v[i];
   return is;
 }
 int main() {
@@ -13,7 +13,7 @@ int main() {
   vi a(1 << n), b(1 << n);
   cin >> a >> b;
   vi c = xor_conv(a, b);
-  for (int i = 0; i < (1 << n); i++) cout << c[i] << ' ';
+  rep(i, 0, (1 << n)) cout << c[i] << ' ';
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/data_structures/binary_search_example.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/binary_search_example.test.cpp
@@ -10,11 +10,10 @@ int main() {
   }
   int n, s;
   cin >> n >> s;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<int> pref_sum(a);
-  for (int i = 1; i < n; i++)
-    pref_sum[i] += pref_sum[i - 1];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
+  vi pref_sum(a);
+  rep(i, 1, n) pref_sum[i] += pref_sum[i - 1];
   auto sum = [&](int l, int r) -> int { //[l,r]
     int res = pref_sum[r];
     if (l) res -= pref_sum[l - 1];
@@ -25,11 +24,11 @@ int main() {
     return 0;
   }
   int res = n;
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     if (sum(i, n - 1) < s) break;
-    int curr = *ranges::partition_point(views::iota(i, n),
+    int cur = *ranges::partition_point(views::iota(i, n),
       [&](int x) -> bool { return sum(i, x) < s; });
-    res = min(res, curr - i + 1);
+    res = min(res, cur - i + 1);
   }
   cout << res << '\n';
   return 0;

--- a/tests/library_checker_aizu_tests/data_structures/bit.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit.test.cpp
@@ -10,8 +10,8 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> arr(n);
-  vector<int> arr_int(n);
-  for (int i = 0; i < n; i++) {
+  vi arr_int(n);
+  rep(i, 0, n) {
     cin >> arr[i];
     arr_int[i] = int(arr[i]);
   }
@@ -21,7 +21,7 @@ int main() {
   vector<ll> suf_sum(n);
   partial_sum(rbegin(arr), rend(arr), rbegin(suf_sum));
   bit_rupq bit_i(suf_sum);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     assert(arr[i] == bit.query(i, i + 1));
     assert(bit_i.get_index(i) == bit.query(i, n));
     assert(bit_i.get_index(i) == suf_sum[i]);

--- a/tests/library_checker_aizu_tests/data_structures/bit_inc.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_inc.test.cpp
@@ -7,7 +7,7 @@ int main() {
   int n, q;
   cin >> n >> q;
   BIT bit(n);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int val;
     cin >> val;
     bit.update(i, val);

--- a/tests/library_checker_aizu_tests/data_structures/bit_inc_walk.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_inc_walk.test.cpp
@@ -8,7 +8,7 @@ int main() {
   string s;
   cin >> n >> q >> s;
   vector<ll> init(n);
-  for (int i = 0; i < n; i++) init[i] = s[i] - '0';
+  rep(i, 0, n) init[i] = s[i] - '0';
   BIT bit(init);
   while (q--) {
     int type, k;

--- a/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
@@ -17,7 +17,8 @@ int main() {
     compress.push_back(x);
   }
   ranges::sort(compress);
-  compress.erase(unique(all(compress)), end(compress));
+  compress.erase(begin(ranges::unique(compress)),
+    end(compress));
   BIT bit(sz(compress));
   auto get_compressed_idx = [&](int val) -> int {
     int l = 0, r = sz(compress);

--- a/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
@@ -17,8 +17,7 @@ int main() {
     compress.push_back(x);
   }
   ranges::sort(compress);
-  compress.erase(begin(ranges::unique(compress)),
-    end(compress));
+  compress.erase(unique(all(compress)), end(compress));
   BIT bit(sz(compress));
   auto get_compressed_idx = [&](int val) -> int {
     int l = 0, r = sz(compress);

--- a/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_ordered_set.test.cpp
@@ -6,21 +6,22 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> init(n);
-  for (int i = 0; i < n; i++) cin >> init[i];
-  vector<int> compress(init);
+  vi init(n);
+  rep(i, 0, n) cin >> init[i];
+  vi compress(init);
   vector<array<int, 2>> query(q);
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int type, x;
     cin >> type >> x;
     query[i] = {type, x};
     compress.push_back(x);
   }
   ranges::sort(compress);
-  compress.erase(unique(all(compress)), end(compress));
-  BIT bit(ssize(compress));
+  compress.erase(begin(ranges::unique(compress)),
+    end(compress));
+  BIT bit(sz(compress));
   auto get_compressed_idx = [&](int val) -> int {
-    int l = 0, r = ssize(compress);
+    int l = 0, r = sz(compress);
     while (l + 1 < r) {
       int m = (l + r) / 2;
       if (compress[m] <= val) l = m;
@@ -28,7 +29,7 @@ int main() {
     }
     return l;
   };
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int val = get_compressed_idx(init[i]);
     bit.update(val, 1);
   }
@@ -41,7 +42,7 @@ int main() {
       if (bit.query(x, x) == 1) bit.update(x, -1);
     } else if (type == 2) {
       int res = bit.walk2(x);
-      if (res == -1 || res == ssize(compress))
+      if (res == -1 || res == sz(compress))
         cout << -1 << '\n';
       else cout << compress[res] << '\n';
     } else if (type == 3) {
@@ -55,7 +56,7 @@ int main() {
     } else {
       x = get_compressed_idx(x);
       int res = bit.walk2(bit.query(x - 1) + 1);
-      if (res == ssize(bit.s)) cout << -1 << '\n';
+      if (res == sz(bit.s)) cout << -1 << '\n';
       else cout << compress[res] << '\n';
     }
   }

--- a/tests/library_checker_aizu_tests/data_structures/bit_walk.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/bit_walk.test.cpp
@@ -8,10 +8,9 @@ int main() {
   int n, q;
   string s;
   cin >> n >> q >> s;
-  vector<int> init(n);
+  vi init(n);
   vector<ll> init_ll(n);
-  for (int i = 0; i < n; i++)
-    init[i] = init_ll[i] = s[i] - '0';
+  rep(i, 0, n) init[i] = init_ll[i] = s[i] - '0';
   BIT bit(init_ll);
   seg_tree st(init);
   while (q--) {
@@ -39,7 +38,7 @@ int main() {
       }
       int order = bit.query(k);
       int need = order + 1;
-      auto f = [&](int64_t x, int tl, int tr) -> bool {
+      auto f = [&](ll x, int tl, int tr) -> bool {
         assert(tl <= tr);
         if (x < need) {
           need -= x;
@@ -50,7 +49,7 @@ int main() {
       int res = bit.walk2(order + 1);
       assert(res == st.find_first(0, n, f));
       assert(res == st.find_first(k, n,
-                      [&](int64_t x, int, int) -> bool {
+                      [&](ll x, int, int) -> bool {
                         return x > 0;
                       }));
       if (res == n) res = -1;
@@ -71,7 +70,7 @@ int main() {
       }
       int order = bit.query(k);
       int need = order;
-      auto f = [&](int64_t x, int tl, int tr) -> bool {
+      auto f = [&](ll x, int tl, int tr) -> bool {
         assert(tl <= tr);
         if (x < need) {
           need -= x;
@@ -82,7 +81,7 @@ int main() {
       int res = bit.walk2(order);
       assert(max(res, 0) == st.find_first(0, n, f));
       assert(res == st.find_last(0, k + 1,
-                      [&](int64_t x, int, int) -> bool {
+                      [&](ll x, int, int) -> bool {
                         return x > 0;
                       }));
       int res_lambda = -1;

--- a/tests/library_checker_aizu_tests/data_structures/deque.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/deque.test.cpp
@@ -6,7 +6,7 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int q;
   cin >> q;
-  deq dq(vector<int>(),
+  deq dq(vi(),
     [](int x, int y) -> int { return min(x, y); });
   while (q--) {
     int type;

--- a/tests/library_checker_aizu_tests/data_structures/deque_index.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/deque_index.test.cpp
@@ -5,7 +5,7 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int q;
   cin >> q;
-  deq dq(vector<int>(),
+  deq dq(vi(),
     [](int x, int y) -> int { return min(x, y); });
   while (q--) {
     int type;

--- a/tests/library_checker_aizu_tests/data_structures/deque_op.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/deque_op.test.cpp
@@ -8,7 +8,7 @@ int main() {
   const int mod = 998'244'353;
   int q;
   cin >> q;
-  using line = pair<int, int>;
+  using line = pii;
   // f1 = begin, f2 = second after begin
   // we want op(f1, f2) = the function f2(f1(x))
   deq dq(vector<line>(),
@@ -42,8 +42,8 @@ int main() {
       cin >> x;
       if (dq.siz() == 0) cout << x << '\n';
       else {
-        line curr = dq.query();
-        cout << (1LL * curr.first * x + curr.second) % mod
+        line cur = dq.query();
+        cout << (1LL * cur.first * x + cur.second) % mod
              << '\n';
       }
     }

--- a/tests/library_checker_aizu_tests/data_structures/deque_sliding_window.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/deque_sliding_window.test.cpp
@@ -7,12 +7,12 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, l;
   cin >> n >> l;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
-  vector<int> init(begin(arr), begin(arr) + l);
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
+  vi init(begin(arr), begin(arr) + l);
   deq dq(init, mn);
   cout << dq.query();
-  for (int i = l; i < n; i++) {
+  rep(i, l, n) {
     dq.push_back(arr[i]);
     dq.pop_front();
     cout << " " << dq.query();

--- a/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc.test.cpp
@@ -6,7 +6,7 @@ int main() {
   int n, q;
   cin >> n >> q;
   vi a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  rep(i, 0, n) cin >> a[i];
   disjoint_rmq rmq(a,
     [](int x, int y) { return min(x, y); });
   while (q--) {

--- a/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc_lines.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc_lines.test.cpp
@@ -13,7 +13,7 @@ int main() {
   };
   vector<query> queries(q);
   vector<pair<ll, ll>> lines;
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     cin >> queries[i].type;
     if (queries[i].type == 0) {
       cin >> queries[i].a >> queries[i].b;
@@ -32,14 +32,14 @@ int main() {
         (b.first * a.second + b.second) % mod);
     });
   int l = 0, r = 0; // range [l, r)
-  for (const auto& curr : queries) {
-    if (curr.type == 0) r++;
-    else if (curr.type == 1) l++;
+  for (const auto& cur : queries) {
+    if (cur.type == 0) r++;
+    else if (cur.type == 1) l++;
     else {
-      if (l == r) cout << curr.x << '\n';
+      if (l == r) cout << cur.x << '\n';
       else {
         auto [slope, y_int] = rmq.query(l, r - 1);
-        cout << (slope * curr.x + y_int) % mod << '\n';
+        cout << (slope * cur.x + y_int) % mod << '\n';
       }
     }
   }

--- a/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc_sum.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/disjoint_rmq_inc_sum.test.cpp
@@ -6,9 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int64_t> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
-  disjoint_rmq rmq(arr, plus<int64_t>{});
+  vector<ll> arr(n);
+  rep(i, 0, n) cin >> arr[i];
+  disjoint_rmq rmq(arr, plus<ll>{});
   while (q--) {
     int l, r;
     cin >> l >> r;

--- a/tests/library_checker_aizu_tests/data_structures/distinct_query.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/distinct_query.test.cpp
@@ -6,8 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   distinct_query dq(a);
   while (q--) {
     int l, r;

--- a/tests/library_checker_aizu_tests/data_structures/implicit_seg_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/implicit_seg_tree.test.cpp
@@ -10,24 +10,24 @@ int main() {
     int x, y1, y2, add;
   };
   vector<vertical_edge> edges;
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int x1, y1, x2, y2;
     cin >> x1 >> y1 >> x2 >> y2;
     edges.push_back({x1, y1, y2, 1});
     edges.push_back({x2, y1, y2, -1});
   }
-  sort(begin(edges), end(edges),
+  ranges::sort(edges,
     [&](const vertical_edge& a, const vertical_edge& b)
       -> bool { return a.x < b.x; });
   const int mn = 0, mx = 1'000'000'001;
   implicit_seg_tree<500'000 * 31 * 2 * 2 + 100> ist(mn,
     mx);
-  int64_t area = 0;
+  ll area = 0;
   // sweepline
   for (int i = 0; i < sz(edges);) {
     if (i) {
       auto [curr_mn, cnt_mn] = ist.query(mn, mx);
-      int64_t num_pos = mx - mn;
+      ll num_pos = mx - mn;
       if (curr_mn == 0) num_pos -= cnt_mn;
       area += (edges[i].x - edges[i - 1].x) * num_pos;
     }

--- a/tests/library_checker_aizu_tests/data_structures/kd_bit_1d.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/kd_bit_1d.test.cpp
@@ -8,7 +8,7 @@ int main() {
   cin >> n >> q;
   KD_BIT<1> bit1(n);
   KD_BIT<2> bit2(1, n);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int val;
     cin >> val;
     bit1.update(i, val);

--- a/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
@@ -10,7 +10,7 @@ int main() {
   rep(i, 0, n) cin >> arr[i];
   vi sorted(arr);
   ranges::sort(sorted);
-  sorted.erase(unique(all(sorted)), end(sorted));
+  sorted.erase(begin(ranges::unique(sorted)), end(sorted));
   for (int& val : arr) {
     int start = 0, end = sz(sorted);
     while (start + 1 < end) {

--- a/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
@@ -6,12 +6,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
-  vector<int> sorted(arr);
-  sort(begin(sorted), end(sorted));
-  sorted.erase(unique(begin(sorted), end(sorted)),
-    end(sorted));
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
+  vi sorted(arr);
+  ranges::sort(sorted);
+  sorted.erase(begin(ranges::unique(sorted)), end(sorted));
   for (int& val : arr) {
     int start = 0, end = sz(sorted);
     while (start + 1 < end) {
@@ -23,7 +22,7 @@ int main() {
     val = start - 50;
   }
   kth_smallest st(arr, -50, sz(sorted) - 50);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int mx = arr[i];
     for (int j = i + 1; j <= min(i + 5, n); j++) {
       mx = max(mx, arr[j - 1]);

--- a/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/kth_smallest_pst.test.cpp
@@ -10,7 +10,7 @@ int main() {
   rep(i, 0, n) cin >> arr[i];
   vi sorted(arr);
   ranges::sort(sorted);
-  sorted.erase(begin(ranges::unique(sorted)), end(sorted));
+  sorted.erase(unique(all(sorted)), end(sorted));
   for (int& val : arr) {
     int start = 0, end = sz(sorted);
     while (start + 1 < end) {

--- a/tests/library_checker_aizu_tests/data_structures/kth_smallest_wavelet_matrix.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/kth_smallest_wavelet_matrix.test.cpp
@@ -7,7 +7,7 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> a(n);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     cin >> a[i];
     a[i] <<= 23;
   }

--- a/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree.test.cpp
@@ -8,7 +8,7 @@ int main() {
     // test empty seg tree
     seg_tree st(0);
     st.update(0, 0, 1);
-    int64_t res = st.query(0, 0);
+    ll res = st.query(0, 0);
     assert(res == 0);
   }
   int n, q;
@@ -19,7 +19,7 @@ int main() {
     cin >> type >> l >> r;
     l--;
     if (type == 0) {
-      int64_t x;
+      ll x;
       cin >> x;
       st.update(l, r, x);
       st.update(l, l, 1);
@@ -28,11 +28,11 @@ int main() {
       assert(type == 1);
       cout << st.query(l, r) << '\n';
       {
-        int64_t res = st.query(l, l);
+        ll res = st.query(l, l);
         assert(res == 0);
       }
       {
-        int64_t res = st.query(r, r);
+        ll res = st.query(r, r);
         assert(res == 0);
       }
     }

--- a/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_constructor.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_constructor.test.cpp
@@ -6,22 +6,22 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   {
     // test empty seg tree
-    seg_tree st{vector<int>()};
+    seg_tree st{vi()};
     st.update(0, 0, 1);
-    int64_t res = st.query(0, 0);
+    ll res = st.query(0, 0);
     assert(res == 0);
   }
   int n, q;
   cin >> n >> q;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
   seg_tree st(arr);
   while (q--) {
     int type;
     cin >> type;
     if (type == 0) {
       int idx;
-      int64_t x;
+      ll x;
       cin >> idx >> x;
       st.update(idx, idx + 1, x);
       st.update(idx, idx, 1);
@@ -31,11 +31,11 @@ int main() {
       cin >> l >> r;
       cout << st.query(l, r) << '\n';
       {
-        int64_t res = st.query(l, l);
+        ll res = st.query(l, l);
         assert(res == 0);
       }
       {
-        int64_t res = st.query(r, r);
+        ll res = st.query(r, r);
         assert(res == 0);
       }
     }

--- a/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_inc.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_inc.test.cpp
@@ -12,7 +12,7 @@ int main() {
     cin >> type >> l >> r;
     l--, r--;
     if (type == 0) {
-      int64_t x;
+      ll x;
       cin >> x;
       st.update(l, r, x);
     } else {

--- a/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_inc_constructor.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/lazy_segment_tree_inc_constructor.test.cpp
@@ -6,15 +6,15 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   seg_tree st(a);
   while (q--) {
     int type;
     cin >> type;
     if (type == 0) {
       int idx;
-      int64_t x;
+      ll x;
       cin >> idx >> x;
       st.update(idx, idx, x);
     } else {

--- a/tests/library_checker_aizu_tests/data_structures/merge_sort_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/merge_sort_tree.test.cpp
@@ -9,8 +9,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
   merge_sort_tree mst(arr);
   while (q--) {
     int l, r, x;

--- a/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
@@ -10,7 +10,7 @@ int main() {
   rep(i, 0, n) cin >> a[i];
   vi comp(a);
   ranges::sort(comp);
-  comp.erase(begin(ranges::unique(comp)), end(comp));
+  comp.erase(unique(all(comp)), end(comp));
   for (int& val : a) {
     int start = 0, end = sz(comp);
     while (start + 1 < end) {

--- a/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
@@ -6,11 +6,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<int> comp(a);
-  sort(begin(comp), end(comp));
-  comp.erase(unique(begin(comp), end(comp)), end(comp));
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
+  vi comp(a);
+  ranges::sort(comp);
+  comp.erase(begin(ranges::unique(comp)), end(comp));
   for (int& val : a) {
     int start = 0, end = sz(comp);
     while (start + 1 < end) {

--- a/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/mode_query.test.cpp
@@ -10,7 +10,7 @@ int main() {
   rep(i, 0, n) cin >> a[i];
   vi comp(a);
   ranges::sort(comp);
-  comp.erase(unique(all(comp)), end(comp));
+  comp.erase(begin(ranges::unique(comp)), end(comp));
   for (int& val : a) {
     int start = 0, end = sz(comp);
     while (start + 1 < end) {

--- a/tests/library_checker_aizu_tests/data_structures/permutation_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/permutation_tree.test.cpp
@@ -7,14 +7,14 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   perm_tree pt = perm_tree_asserts(a);
   auto root = pt.root;
   auto ch = pt.ch;
   cout << sz(ch) << '\n';
   int curr_time = 0;
-  vector<int> node_to_time(sz(ch), -1);
+  vi node_to_time(sz(ch), -1);
   auto dfs = [&](auto&& self, int u, int p) -> void {
     node_to_time[u] = curr_time++;
     cout << (p == -1 ? p : node_to_time[p]) << " "

--- a/tests/library_checker_aizu_tests/data_structures/persistent_queue_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/persistent_queue_tree.test.cpp
@@ -7,7 +7,7 @@ int main() {
   int q;
   cin >> q;
   PST pst(0, q);
-  vector<pair<int, int>> bounds(q + 1);
+  vector<pii> bounds(q + 1);
   // bounds[version] = [left index, right index) represents
   // subarray range of queue
   for (int curr_version = 1; curr_version <= q;

--- a/tests/library_checker_aizu_tests/data_structures/persistent_seg_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/persistent_seg_tree.test.cpp
@@ -10,22 +10,22 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<array<int, 3>> points(n);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int x, y, w;
     cin >> x >> y >> w;
     points[i] = {x, y, w};
   }
-  sort(begin(points), end(points));
+  ranges::sort(points);
   PST pst(-5, 1'000'000'000);
   for (const auto& point : points)
     pst.update(point[1], point[2], sz(pst.roots) - 1);
   while (q--) {
     int l, down, r, up;
     cin >> l >> down >> r >> up;
-    l = int(lower_bound(begin(points), end(points),
+    l = int(ranges::lower_bound(points,
               array<int, 3>({l, -1, -1})) -
             begin(points));
-    r = int(lower_bound(begin(points), end(points),
+    r = int(ranges::lower_bound(points,
               array<int, 3>({r, -1, -1})) -
             begin(points));
     cout << pst.query(down, up, r) - pst.query(down, up, l)

--- a/tests/library_checker_aizu_tests/data_structures/pq_ds_undo_sliding_window.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/pq_ds_undo_sliding_window.test.cpp
@@ -6,7 +6,7 @@
 #include "../template.hpp"
 #include "../../../library/data_structures_[l,r)/uncommon/priority_queue_of_updates.hpp"
 struct stack_with_get_max {
-  vector<pair<int, int>> st;
+  vector<pii> st;
   void join(int val) {
     st.emplace_back(val,
       empty(st) ? val : min(val, st.back().second));
@@ -18,16 +18,15 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, l;
   cin >> n >> l;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
   stack_with_get_max stm;
   pq_updates<stack_with_get_max, int> pq(stm);
-  int priority = (n - l) / 2;
-  for (int i = 0; i < l; i++)
-    pq.push_update(arr[i], priority--);
+  int pri = (n - l) / 2;
+  rep(i, 0, l) pq.push_update(arr[i], pri--);
   cout << pq.ds.get_max();
-  for (int i = l; i < n; i++) {
-    pq.push_update(arr[i], priority--);
+  rep(i, l, n) {
+    pq.push_update(arr[i], pri--);
     pq.pop_update();
     cout << " " << pq.ds.get_max();
   }

--- a/tests/library_checker_aizu_tests/data_structures/rmq_linear.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/rmq_linear.test.cpp
@@ -5,12 +5,12 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   linear_rmq rmq_less(a, less());
   linear_rmq rmq_less_equal(a, less_equal());
-  vector<int> neg_a(n);
-  for (int i = 0; i < n; i++) neg_a[i] = -a[i];
+  vi neg_a(n);
+  rep(i, 0, n) neg_a[i] = -a[i];
   linear_rmq rmq_greater(neg_a, greater());
   linear_rmq rmq_greater_equal(neg_a, greater_equal());
   while (q--) {

--- a/tests/library_checker_aizu_tests/data_structures/rmq_sparse_table.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/rmq_sparse_table.test.cpp
@@ -7,8 +7,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   mono_st_asserts(a);
   RMQ rmq(a, ranges::min);
   while (q--) {

--- a/tests/library_checker_aizu_tests/data_structures/rmq_sparse_table_inc.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/rmq_sparse_table_inc.test.cpp
@@ -5,8 +5,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   RMQ rmq(a, ranges::min);
   while (q--) {
     int l, r;

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_line.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_line.test.cpp
@@ -8,7 +8,7 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<array<int, 2>> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i][0] >> a[i][1];
+  rep(i, 0, n) cin >> a[i][0] >> a[i][1];
   tree st(a,
     [&](const array<int, 2>& l,
       const array<int, 2>& r) -> array<int, 2> {

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_queue.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_queue.test.cpp
@@ -11,7 +11,7 @@ int main() {
   cin >> q;
   vector<array<int, 3>> queries(q);
   vector<array<int, 2>> init;
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int type;
     cin >> type;
     if (type == 0) {
@@ -35,7 +35,7 @@ int main() {
   tree st(init, f);
   disjoint_rmq rmq(init, f);
   int l = 0, r = 0; //[l,r)
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int type = queries[i][0];
     if (type == 0) {
       r++;

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_walk.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_inc_walk.test.cpp
@@ -8,8 +8,8 @@ int main() {
   cin >> n >> q;
   string s;
   cin >> s;
-  vector<int> init(n);
-  for (int i = 0; i < n; i++) init[i] = s[i] - '0';
+  vi init(n);
+  rep(i, 0, n) init[i] = s[i] - '0';
   tree st(init, ranges::max);
   while (q--) {
     int type, k;

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_line.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_line.test.cpp
@@ -14,7 +14,7 @@ int main() {
       return {int(1LL * l[0] * r[0] % mod),
         int((1LL * r[0] * l[1] + r[1]) % mod)};
     });
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int a, b;
     cin >> a >> b;
     st.update(i, {a, b});

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_queue.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_queue.test.cpp
@@ -11,7 +11,7 @@ int main() {
   cin >> q;
   vector<array<int, 3>> queries(q);
   vector<array<int, 2>> init;
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int type;
     cin >> type;
     if (type == 0) {
@@ -33,12 +33,11 @@ int main() {
       int((1LL * r[0] * l[1] + r[1]) % mod)};
   };
   const array<int, 2> unit = {1, 0};
-  tree st(ssize(init), unit, f);
-  for (int i = 0; i < ssize(init); i++)
-    st.update(i, init[i]);
+  tree st(sz(init), unit, f);
+  rep(i, 0, sz(init)) st.update(i, init[i]);
   disjoint_rmq rmq(init, f);
   int l = 0, r = 0; //[l,r)
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int type = queries[i][0];
     if (type == 0) {
       r++;

--- a/tests/library_checker_aizu_tests/data_structures/simple_tree_walk.test.cpp
+++ b/tests/library_checker_aizu_tests/data_structures/simple_tree_walk.test.cpp
@@ -9,7 +9,7 @@ int main() {
   tree st(n, INT_MIN, ranges::max);
   string s;
   cin >> s;
-  for (int i = 0; i < n; i++) st.update(i, s[i] - '0');
+  rep(i, 0, n) st.update(i, s[i] - '0');
   while (q--) {
     int type, k;
     cin >> type >> k;

--- a/tests/library_checker_aizu_tests/dsu/dsu_bipartite.test.cpp
+++ b/tests/library_checker_aizu_tests/dsu/dsu_bipartite.test.cpp
@@ -2,17 +2,16 @@
 #include "../template.hpp"
 #include "../../../library/dsu/dsu_bipartite.hpp"
 #include "../../../library/contest/random.hpp"
-vector<bool> bipartite_check(
-  const vector<vector<int>>& adj) {
+vector<bool> bipartite_check(const vector<vi>& adj) {
   int n = sz(adj);
   vector<bool> is_bi(n);
-  vector<int> color(n, -1);
-  for (int s = 0; s < n; s++) {
+  vi color(n, -1);
+  rep(s, 0, n) {
     if (color[s] != -1) continue;
     color[s] = 0;
-    vector<int> q{s};
+    vi q{s};
     bool is_bipartite = 1;
-    for (int fr = 0; fr < sz(q); fr++) {
+    rep(fr, 0, sz(q)) {
       int u = q[fr];
       for (int v : adj[u])
         if (color[v] == -1) {
@@ -29,13 +28,12 @@ int main() {
   int n, q;
   cin >> n >> q;
   dsu_bipartite dsu(n);
-  vector<vector<int>> adj(n);
+  vector<vi> adj(n);
   auto check = [&]() {
     vector<bool> is_bi = bipartite_check(adj);
-    for (int s = 0; s < n; s++)
-      assert(dsu.is_bipartite(s) == is_bi[s]);
+    rep(s, 0, n) assert(dsu.is_bipartite(s) == is_bi[s]);
   };
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int t, u, v;
     cin >> t >> u >> v;
     if (t == 0) {

--- a/tests/library_checker_aizu_tests/dsu/kruskal_tree_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/dsu/kruskal_tree_aizu.test.cpp
@@ -7,9 +7,9 @@ int main() {
   int n;
   cin >> n;
   vector<array<int, 3>> w_eds;
-  vector<vector<int>> mat(n, vector<int>(n));
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < n; j++) {
+  vector<vi> mat(n, vi(n));
+  rep(i, 0, n) {
+    rep(j, 0, n) {
       cin >> mat[i][j];
       if (mat[i][j] == -1) {
         mat[i][j] = INT_MAX;
@@ -18,18 +18,18 @@ int main() {
       w_eds.push_back({mat[i][j], i, j});
     }
   }
-  sort(all(w_eds));
+  ranges::sort(w_eds);
   kr_tree kt(n);
-  vector<int> weight(2 * n);
+  vi weight(2 * n);
   for (auto [w, u, v] : w_eds)
     if (kt.join(u, v)) weight[kt.id - 1] = w;
   rep(k, 0, n) rep(i, 0, n) rep(j, 0, n) {
     mat[i][j] = min(mat[i][j], max(mat[i][k], mat[k][j]));
   }
   int mst_sum = 0;
-  for (int i = n; i < kt.id; i++) mst_sum += weight[i];
-  vector<int> depth(2 * n);
-  vector<int> actual_par(2 * n, -1);
+  rep(i, n, kt.id) mst_sum += weight[i];
+  vi depth(2 * n);
+  vi actual_par(2 * n, -1);
   auto dfs = [&](auto&& self, int v) -> void {
     for (int u : kt.g[v]) {
       depth[u] = 1 + depth[v];

--- a/tests/library_checker_aizu_tests/dsu/line_tree_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/dsu/line_tree_aizu.test.cpp
@@ -8,9 +8,9 @@ int main() {
   int n;
   cin >> n;
   vector<array<int, 3>> w_eds;
-  vector<vector<int>> mat(n, vector<int>(n));
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < n; j++) {
+  vector<vi> mat(n, vi(n));
+  rep(i, 0, n) {
+    rep(j, 0, n) {
       cin >> mat[i][j];
       if (mat[i][j] == -1) {
         mat[i][j] = INT_MAX;
@@ -21,13 +21,13 @@ int main() {
   }
   rep(k, 0, n) rep(i, 0, n) rep(j, 0, n)
     mat[i][j] = min(mat[i][j], max(mat[i][k], mat[k][j]));
-  sort(all(w_eds));
+  ranges::sort(w_eds);
   line_tree lt(n);
   for (auto [w, u, v] : w_eds) lt.join(u, v);
   assert(lt.size(0) == n);
   int mst_sum = 0;
-  vector<int> edge_weights;
-  vector<int> to_time(n);
+  vi edge_weights;
+  vi to_time(n);
   for (int v = lt.f(0), timer = 1;
     lt.edge[v] != pii{-1, -1};
     v = lt.edge[v].first, timer++) {

--- a/tests/library_checker_aizu_tests/dsu/line_tree_lib_checker.test.cpp
+++ b/tests/library_checker_aizu_tests/dsu/line_tree_lib_checker.test.cpp
@@ -8,20 +8,20 @@ int main() {
   int n, m;
   cin >> n >> m;
   vector<array<int, 3>> w_eds(m);
-  vector<int> weights(m);
-  for (int i = 0; i < m; i++) {
+  vi weights(m);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v >> weights[i];
     w_eds[i] = {i, u, v};
   }
-  sort(all(w_eds),
+  ranges::sort(w_eds,
     [&](const array<int, 3>& x, const array<int, 3>& y)
       -> bool { return weights[x[0]] < weights[y[0]]; });
   line_tree lt(n);
   for (auto [i, u, v] : w_eds) lt.join(u, v);
   assert(lt.size(0) == n);
-  int64_t cost = 0;
-  vector<int> ids;
+  ll cost = 0;
+  vi ids;
   for (int v = lt.f(0); lt.edge[v].first != -1;
     v = lt.edge[v].first) {
     ids.push_back(w_eds[lt.edge[v].second][0]);
@@ -29,7 +29,7 @@ int main() {
   }
   {
     kr_tree kt(n);
-    int64_t kr_tree_cost = 0;
+    ll kr_tree_cost = 0;
     for (auto [e_id, u, v] : w_eds)
       if (kt.join(u, v)) kr_tree_cost += weights[e_id];
     assert(kr_tree_cost == cost);

--- a/tests/library_checker_aizu_tests/dsu/range_parallel_dsu.test.cpp
+++ b/tests/library_checker_aizu_tests/dsu/range_parallel_dsu.test.cpp
@@ -11,9 +11,9 @@ int main() {
   cin >> n >> q;
   rp_dsu r_dsu(n);
   vi y(n);
-  for (int i = 0; i < n; i++) cin >> y[i];
+  rep(i, 0, n) cin >> y[i];
   vi x = y;
-  int ans = 0;
+  int res = 0;
   DSU dsu(n);
   auto f = [&](int u, int v) {
     u = dsu.f(u);
@@ -21,28 +21,28 @@ int main() {
     assert(dsu.join(u, v));
     int root = dsu.f(u);
     int other = root ^ u ^ v;
-    ans = (ans + 1LL * x[root] * x[other]) % mod;
+    res = (res + 1LL * x[root] * x[other]) % mod;
     x[root] = (x[root] + x[other]) % mod;
   };
   vector<vector<pii>> joins(n + 1);
-  for (int qq = 0; qq < q; qq++) {
+  rep(qq, 0, q) {
     int k, a, b;
     cin >> k >> a >> b;
     if (k) r_dsu.join(a, b, k, f);
     joins[k].emplace_back(a, b);
-    cout << ans << '\n';
+    cout << res << '\n';
     if (qq == 0 || qq == 1 || qq == 10 || qq == 1000 ||
         qq == 100'000 || qq == q - 1) {
       auto uf = get_rp_dsu(joins, n);
       vi sums(n);
       int offline_ans = 0;
-      for (int i = 0; i < n; i++) {
+      rep(i, 0, n) {
         int id = uf.f(i);
         offline_ans =
           (offline_ans + 1LL * sums[id] * y[i]) % mod;
         sums[id] = (sums[id] + y[i]) % mod;
       }
-      assert(ans == offline_ans);
+      assert(res == offline_ans);
     }
   }
   return 0;

--- a/tests/library_checker_aizu_tests/edge_cd_asserts.hpp
+++ b/tests/library_checker_aizu_tests/edge_cd_asserts.hpp
@@ -12,7 +12,7 @@ auto edge_cd_asserts = [&](int cent, int split) -> void {
   array<int, 2> cnts = {0, 0};
   array<int, 2> max_cnt = {0, 0};
   array<int, 2> number_of_cnts = {0, 0};
-  for (int i = 0; i < sz(adj[cent]); i++) {
+  rep(i, 0, sz(adj[cent])) {
     int sz_subtree = dfs(dfs, adj[cent][i], cent);
     assert(2 * sz_subtree <= sz_all);
     cnts[i < split] += sz_subtree;

--- a/tests/library_checker_aizu_tests/graphs/bcc_callback_aizu_bcc.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/bcc_callback_aizu_bcc.test.cpp
@@ -6,9 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n; i++) adj[i].push_back(i);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n) adj[i].push_back(i);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/graphs/bcc_callback_aizu_two_edge_cc.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/bcc_callback_aizu_two_edge_cc.test.cpp
@@ -7,8 +7,8 @@ int main() {
   int n, m;
   cin >> n >> m;
   vector<vi> adj(n);
-  for (int i = 0; i < n; i++) adj[i].push_back(i);
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, n) adj[i].push_back(i);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/graphs/bcc_callback_lib_checker_bcc.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/bcc_callback_lib_checker_bcc.test.cpp
@@ -6,26 +6,25 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n; i++) adj[i].push_back(i);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n) adj[i].push_back(i);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
     adj[v].push_back(u);
   }
   vector<bool> vis(n, 0);
-  vector<vector<int>> all_bccs;
+  vector<vi> all_bccs;
   bcc(adj, [&](const vi& nodes) {
-    assert(ssize(nodes) >= 2);
+    assert(sz(nodes) >= 2);
     for (int v : nodes) vis[v] = 1;
     all_bccs.push_back(nodes);
   });
-  for (int i = 0; i < n; i++)
-    if (!vis[i]) all_bccs.push_back({i});
-  cout << ssize(all_bccs) << '\n';
-  for (const vector<int>& other_nodes : all_bccs) {
-    cout << ssize(other_nodes) << ' ';
+  rep(i, 0, n) if (!vis[i]) all_bccs.push_back({i});
+  cout << sz(all_bccs) << '\n';
+  for (const vi& other_nodes : all_bccs) {
+    cout << sz(other_nodes) << ' ';
     for (int v : other_nodes) cout << v << ' ';
     cout << '\n';
   }

--- a/tests/library_checker_aizu_tests/graphs/bcc_callback_lib_checker_two_cc.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/bcc_callback_lib_checker_two_cc.test.cpp
@@ -8,20 +8,20 @@ int main() {
   int n, m;
   cin >> n >> m;
   vector<vi> adj(n);
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
     adj[v].push_back(u);
   }
   DSU dsu(n);
-  vector<bool> seen(n);
+  vector<bool> vis(n);
   bcc(adj, [&](const vi& nodes) {
     int count_edges = 0;
     rep(i, 0, sz(nodes) - 1) {
-      seen[nodes[i]] = 1;
+      vis[nodes[i]] = 1;
       count_edges += ranges::count_if(adj[nodes[i]],
-        [&](int v) -> bool { return !seen[v]; });
+        [&](int v) -> bool { return !vis[v]; });
     }
     if (count_edges == 1) {
       assert(sz(nodes) == 2);

--- a/tests/library_checker_aizu_tests/graphs/biconnected_components.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/biconnected_components.test.cpp
@@ -6,9 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<pair<int, int>>> adj(n);
-  vector<pair<int, int>> edges(m);
-  for (int i = 0; i < m; i++) {
+  vector<vector<pii>> adj(n);
+  vector<pii> edges(m);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].emplace_back(v, i);
@@ -17,20 +17,18 @@ int main() {
   }
   auto [num_bccs, bcc_id, is_cut] = cuts(adj, m);
   auto bvt = block_vertex_tree(adj, num_bccs, bcc_id);
-  assert(
-    find(begin(bcc_id), end(bcc_id), -1) == end(bcc_id));
-  for (int i = 0; i < n; i++) {
+  assert(ranges::find(bcc_id, -1) == end(bcc_id));
+  rep(i, 0, n) {
     // cut node if there exists a pair of adjacent edges
     // belonging to different BCCs
     bool curr_is_cut = 0;
-    for (int j = 0; j < sz(adj[i]); j++)
-      if (bcc_id[adj[i][0].second] !=
-          bcc_id[adj[i][j].second])
-        curr_is_cut = 1;
+    rep(j, 0, sz(adj[i])) if (
+      bcc_id[adj[i][0].second] != bcc_id[adj[i][j].second])
+      curr_is_cut = 1;
     assert(curr_is_cut == is_cut[i]);
   }
   // check correctness of block vertex tree
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     // in particular, if empty(adj[i]), then empty(bct[i])
     assert(sz(adj[i]) >= sz(bvt[i]));
     // is cut means non-leaf in block vertex tree
@@ -39,7 +37,7 @@ int main() {
   {
     vector<set<int>> bcc_to_nodes(num_bccs),
       node_to_bccs(n);
-    for (int i = 0; i < m; i++) {
+    rep(i, 0, m) {
       int bccid = bcc_id[i];
       for (auto node : {edges[i].first, edges[i].second}) {
         bcc_to_nodes[bccid].insert(node);
@@ -47,25 +45,24 @@ int main() {
       }
     }
     // testing commented loops in block_vertex_tree
-    for (int u = 0; u < n; u++) {
+    rep(u, 0, n) {
       assert(sz(node_to_bccs[u]) == sz(bvt[u]));
       for (auto bccid : bvt[u]) {
         bccid -= n;
         assert(node_to_bccs[u].contains(bccid));
       }
     }
-    for (int bccid = 0; bccid < num_bccs; bccid++) {
+    rep(bccid, 0, num_bccs) {
       assert(
         sz(bcc_to_nodes[bccid]) == sz(bvt[bccid + n]));
       for (auto u : bvt[bccid + n])
         assert(bcc_to_nodes[bccid].contains(u));
     }
   }
-  vector<int> lone_nodes;
-  for (int u = 0; u < n; u++)
-    if (empty(bvt[u])) lone_nodes.push_back(u);
+  vi lone_nodes;
+  rep(u, 0, n) if (empty(bvt[u])) lone_nodes.push_back(u);
   cout << num_bccs + sz(lone_nodes) << '\n';
-  for (int bccid = 0; bccid < num_bccs; bccid++) {
+  rep(bccid, 0, num_bccs) {
     cout << sz(bvt[bccid + n]) << " ";
     for (auto u : bvt[bccid + n]) cout << u << " ";
     cout << '\n';

--- a/tests/library_checker_aizu_tests/graphs/connected_components_of_complement_graph.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/connected_components_of_complement_graph.test.cpp
@@ -6,17 +6,17 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
     adj[v].push_back(u);
   }
   auto cc_id = get_complement_graph_ccs(adj);
-  int num_ccs = *max_element(begin(cc_id), end(cc_id)) + 1;
-  vector<vector<int>> ccs(num_ccs);
-  for (int u = 0; u < n; u++) ccs[cc_id[u]].push_back(u);
+  int num_ccs = *ranges::max_element(cc_id) + 1;
+  vector<vi> ccs(num_ccs);
+  rep(u, 0, n) ccs[cc_id[u]].push_back(u);
   cout << num_ccs << '\n';
   for (auto& cc : ccs) {
     cout << size(cc);

--- a/tests/library_checker_aizu_tests/graphs/dijkstra_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/dijkstra_aizu.test.cpp
@@ -11,14 +11,12 @@ int main() {
   int n, m, s;
   cin >> n >> m >> s;
   vector<vector<pair<int, ll>>> adj(n);
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     int u, v, w;
     cin >> u >> v >> w;
     adj[u].emplace_back(v, w);
   }
   vector<ll> len = dijkstra(adj, s);
-  for (int i = 0; i < n; i++)
-    if (len[i] == LLONG_MAX) cout << "INF\n";
-    else cout << len[i] << '\n';
-  return 0;
+  rep(i, 0, n) if (len[i] == LLONG_MAX) cout << "INF\n";
+  else cout << len[i] << '\n'; return 0;
 }

--- a/tests/library_checker_aizu_tests/graphs/dijkstra_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/dijkstra_aizu.test.cpp
@@ -17,6 +17,9 @@ int main() {
     adj[u].emplace_back(v, w);
   }
   vector<ll> len = dijkstra(adj, s);
-  rep(i, 0, n) if (len[i] == LLONG_MAX) cout << "INF\n";
-  else cout << len[i] << '\n'; return 0;
+  rep(i, 0, n) {
+    if (len[i] == LLONG_MAX) cout << "INF\n";
+    else cout << len[i] << '\n';
+  }
+  return 0;
 }

--- a/tests/library_checker_aizu_tests/graphs/dijkstra_lib_checker.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/dijkstra_lib_checker.test.cpp
@@ -11,7 +11,7 @@ int main() {
   int n, m, s, t;
   cin >> n >> m >> s >> t;
   vector<vector<pair<int, ll>>> adj(n), adj_inv(n);
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     int u, v, w;
     cin >> u >> v >> w;
     adj[u].emplace_back(v, w);

--- a/tests/library_checker_aizu_tests/graphs/directed_cycle.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/directed_cycle.test.cpp
@@ -6,9 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  vector<vector<pair<int, int>>> adj_edge_id(n);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  vector<vector<pii>> adj_edge_id(n);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
@@ -32,9 +32,9 @@ int main() {
       vi vis(n);
       while (!vis[v]) {
         vis[v] = 1;
-        for (auto [next, _] : adj_edge_id[v]) {
-          if (scc_id[v] == scc_id[next]) {
-            v = next;
+        for (auto [nxt, _] : adj_edge_id[v]) {
+          if (scc_id[v] == scc_id[nxt]) {
+            v = nxt;
             break;
           }
         }
@@ -42,10 +42,10 @@ int main() {
       vi cycle;
       while (vis[v] == 1) {
         vis[v] = 2;
-        for (auto [next, e_id] : adj_edge_id[v]) {
-          if (scc_id[v] == scc_id[next]) {
+        for (auto [nxt, e_id] : adj_edge_id[v]) {
+          if (scc_id[v] == scc_id[nxt]) {
             cycle.push_back(e_id);
-            v = next;
+            v = nxt;
             break;
           }
         }

--- a/tests/library_checker_aizu_tests/graphs/enumerate_triangles.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/enumerate_triangles.test.cpp
@@ -6,12 +6,12 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<int> vals(n);
-  for (int i = 0; i < n; i++) cin >> vals[i];
-  vector<pair<int, int>> edges(m);
+  vi vals(n);
+  rep(i, 0, n) cin >> vals[i];
+  vector<pii> edges(m);
   for (auto& [u, v] : edges) cin >> u >> v;
   const int mod = 998'244'353;
-  int64_t sum = 0;
+  ll sum = 0;
   auto enumerate = [&](int u, int v, int w) {
     sum = (sum + 1LL * vals[u] * vals[v] % mod * vals[w] %
                    mod) %

--- a/tests/library_checker_aizu_tests/graphs/euler_walk_directed.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/euler_walk_directed.test.cpp
@@ -20,7 +20,7 @@ int main() {
       deg[u]++;
       deg[v]--;
     }
-    if (*max_element(all(deg)) >= 2) {
+    if (*ranges::max_element(deg) >= 2) {
       cout << "No" << '\n';
       continue;
     }
@@ -32,7 +32,7 @@ int main() {
     if (it != end(deg)) s = it - begin(deg);
     else if (s == -1) s = 0;
     vector<pii> res = euler_path(adj, m, s);
-    if (ssize(res) != m + 1) {
+    if (sz(res) != m + 1) {
       cout << "No" << '\n';
       continue;
     }

--- a/tests/library_checker_aizu_tests/graphs/euler_walk_undirected.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/euler_walk_undirected.test.cpp
@@ -29,7 +29,7 @@ int main() {
     if (it != end(deg)) s = it - begin(deg);
     else if (s == -1) s = 0;
     vector<pii> res = euler_path(adj, m, s);
-    if (ssize(res) != m + 1) {
+    if (sz(res) != m + 1) {
       cout << "No" << '\n';
       continue;
     }

--- a/tests/library_checker_aizu_tests/graphs/hopcroft_karp_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/hopcroft_karp_aizu.test.cpp
@@ -6,8 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int l, r, m;
   cin >> l >> r >> m;
-  vector<vector<int>> adj(l);
-  vector<pair<int, int>> edges;
+  vector<vi> adj(l);
+  vector<pii> edges;
   while (m--) {
     int u, v;
     cin >> u >> v;
@@ -18,12 +18,11 @@ int main() {
   int size_matching = hopcroftKarp(adj, ri);
   auto [mvc_l, mvc_r] = cover(adj, ri);
   int size_r = 0;
-  for (int i = 0; i < r; i++)
-    if (ri[i] != -1) size_r++;
+  rep(i, 0, r) if (ri[i] != -1) size_r++;
   assert(size_r == size_matching);
   // asserting found min vertex cover is correct
-  int cnt = accumulate(begin(mvc_l), end(mvc_l), 0) +
-            accumulate(begin(mvc_r), end(mvc_r), 0);
+  int cnt =
+    accumulate(all(mvc_l), 0) + accumulate(all(mvc_r), 0);
   assert(cnt == size_matching);
   for (auto [u, v] : edges) assert(mvc_l[u] || mvc_r[v]);
   cout << size_matching << '\n';

--- a/tests/library_checker_aizu_tests/graphs/hopcroft_karp_lib_checker.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/hopcroft_karp_lib_checker.test.cpp
@@ -6,8 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int l, r, m;
   cin >> l >> r >> m;
-  vector<vector<int>> adj(l);
-  vector<pair<int, int>> edges;
+  vector<vi> adj(l);
+  vector<pii> edges;
   while (m--) {
     int u, v;
     cin >> u >> v;
@@ -19,15 +19,15 @@ int main() {
   auto [mvc_l, mvc_r] = cover(adj, ri);
   cout << m_sz << '\n';
   int size_r = 0;
-  for (int i = 0; i < r; i++) {
+  rep(i, 0, r) {
     if (ri[i] != -1) {
       size_r++;
       cout << ri[i] << ' ' << i << '\n';
     }
   }
   assert(size_r == m_sz);
-  int cnt = accumulate(begin(mvc_l), end(mvc_l), 0) +
-            accumulate(begin(mvc_r), end(mvc_r), 0);
+  int cnt =
+    accumulate(all(mvc_l), 0) + accumulate(all(mvc_r), 0);
   assert(cnt == m_sz);
   for (auto [u, v] : edges) assert(mvc_l[u] || mvc_r[v]);
   return 0;

--- a/tests/library_checker_aizu_tests/graphs/offline_incremental_scc.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/offline_incremental_scc.test.cpp
@@ -8,18 +8,17 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<int> xs(n);
-  for (int i = 0; i < n; i++) cin >> xs[i];
+  vi xs(n);
+  rep(i, 0, n) cin >> xs[i];
   vector<array<int, 2>> eds(m);
   for (auto& [u, v] : eds) cin >> u >> v;
   auto joins = offline_incremental_scc(eds, n);
   // assert joins[i] == -1 for self-edges
-  for (int t = 0; t < m; t++)
+  rep(t, 0, m)
     assert((eds[t][0] == eds[t][1]) == (joins[t] == -1));
-  vector<int> order(m);
+  vi order(m);
   iota(all(order), 0);
-  ranges::sort(all(order), {},
-    [&](int i) { return joins[i]; });
+  ranges::sort(order, {}, [&](int i) { return joins[i]; });
   DSU dsu(n);
   int sum = 0;
   for (int t = 0, it = 0; t < m; t++) {

--- a/tests/library_checker_aizu_tests/graphs/strongly_connected_components_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/strongly_connected_components_aizu.test.cpp
@@ -7,8 +7,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/graphs/strongly_connected_components_lib_checker.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/strongly_connected_components_lib_checker.test.cpp
@@ -6,8 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < m; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
@@ -15,9 +15,8 @@ int main() {
   scc_asserts(adj);
   auto [num_sccs, scc_id] = scc(adj);
   cout << num_sccs << '\n';
-  vector<vector<int>> each_scc(num_sccs);
-  for (int i = 0; i < n; i++)
-    each_scc[scc_id[i]].push_back(i);
+  vector<vi> each_scc(num_sccs);
+  rep(i, 0, n) each_scc[scc_id[i]].push_back(i);
   for (int i = num_sccs - 1; i >= 0; i--) {
     cout << sz(each_scc[i]) << " ";
     for (auto node : each_scc[i]) cout << node << " ";

--- a/tests/library_checker_aizu_tests/graphs/two_edge_components.test.cpp
+++ b/tests/library_checker_aizu_tests/graphs/two_edge_components.test.cpp
@@ -7,9 +7,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<pair<int, int>>> adj(n);
-  vector<pair<int, int>> edges(m);
-  for (int i = 0; i < m; i++) {
+  vector<vector<pii>> adj(n);
+  vector<pii> edges(m);
+  rep(i, 0, m) {
     int u, v;
     cin >> u >> v;
     adj[u].emplace_back(v, i);
@@ -18,47 +18,45 @@ int main() {
   }
   auto [num_ccs, br_id, is_br] = bridges(adj, m);
   auto bt = bridge_tree(adj, num_ccs, br_id, is_br);
-  assert(find(begin(br_id), end(br_id), -1) == end(br_id));
+  assert(ranges::find(br_id, -1) == end(br_id));
   // check correctness of bridge tree
   {
     assert(sz(bt) == num_ccs);
-    for (int v = 0; v < num_ccs; v++)
-      for (auto to : bt[v])
-        assert(to != v); // didn't add any non-bridge
-    int sum_deg = accumulate(begin(bt), end(bt), 0,
+    rep(v, 0, num_ccs) for (auto to : bt[v])
+      assert(to != v); // didn't add any non-bridge
+    int sum_deg = accumulate(all(bt), 0,
       [](int sum, const auto& neighbors) -> int {
         return sum + sz(neighbors);
       });
-    int cnt_bridges =
-      accumulate(begin(is_br), end(is_br), 0);
+    int cnt_bridges = accumulate(all(is_br), 0);
     assert(sum_deg % 2 == 0 && sum_deg / 2 == cnt_bridges);
   }
   DSU dsu(n);
   int num_sets_dsu = n;
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     if (!is_br[i]) {
       auto [u, v] = edges[i];
       num_sets_dsu -= dsu.join(u, v);
     }
   }
   assert(num_sets_dsu == sz(bt));
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     if (is_br[i]) {
       auto [u, v] = edges[i];
       assert(dsu.f(u) != dsu.f(v));
     }
   }
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     int par_of_cc = dsu.f(i);
     assert(br_id[i] == br_id[par_of_cc]);
   }
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     auto [u, v] = edges[i];
     // bridge if nodes are from different 2-edge CCs
     assert(is_br[i] == (br_id[u] != br_id[v]));
   }
-  vector<vector<int>> ccs(num_ccs);
-  for (int i = 0; i < n; i++) ccs[br_id[i]].push_back(i);
+  vector<vi> ccs(num_ccs);
+  rep(i, 0, n) ccs[br_id[i]].push_back(i);
   cout << num_ccs << '\n';
   for (const auto& curr_cc : ccs) {
     cout << sz(curr_cc) << " ";

--- a/tests/library_checker_aizu_tests/handmade_tests/count_paths.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/count_paths.test.cpp
@@ -50,8 +50,8 @@ vector<vector<ll>> naive(const vector<vi>& adj) {
   LCA lc(adj);
   int n = sz(adj);
   vector<vector<ll>> cnts_naive(n + 1, vector<ll>(n, 0));
-  for (int u = 0; u < n; u++) {
-    for (int v = u; v < n; v++) {
+  rep(u, 0, n) {
+    rep(v, u, n) {
       int path_length_edges = lc.dist(u, v);
       for (int node = u; node != v;
         node = lc.next_on_path(node, v))
@@ -90,7 +90,7 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (int n = 1; n <= 100; n++) {
     vector<vi> adj(n);
-    for (int i = 1; i < n; i++) {
+    rep(i, 1, n) {
       int par = rnd<int>(0, i - 1);
       adj[par].push_back(i);
       adj[i].push_back(par);
@@ -101,7 +101,7 @@ int main() {
       assert(
         count_paths_per_node(adj, k) == cnts_naive[k]);
     vector<ll> num_paths_len = count_paths_per_length(adj);
-    for (int k = 1; k < n; k++) {
+    rep(k, 1, n) {
       vector<ll> count_paths =
         count_paths_per_node(adj, k);
       ll total_paths = accumulate(begin(count_paths),

--- a/tests/library_checker_aizu_tests/handmade_tests/dsu.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/dsu.test.cpp
@@ -6,9 +6,9 @@
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (int n = 0; n <= 100; n++) {
-    vector<vector<int>> adj(n);
+    vector<vi> adj(n);
     DSU dsu(n);
-    for (int q = 0; q < n; q++) {
+    rep(q, 0, n) {
       int u = rnd(0, n - 1);
       int v = rnd(0, n - 1);
       bool joined = dsu.join(u, v);
@@ -28,7 +28,7 @@ int main() {
       }
       adj[u].push_back(v);
       adj[v].push_back(u);
-      for (int i = 0; i < n; i++) {
+      rep(i, 0, n) {
         vector<bool> vis(n);
         int cnt_nodes = 0;
         auto dfs = [&](auto&& self, int v) -> void {

--- a/tests/library_checker_aizu_tests/handmade_tests/edge_cd_small_trees.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/edge_cd_small_trees.test.cpp
@@ -5,31 +5,30 @@
 #include "../../../library/trees/edge_cd.hpp"
 int main() {
   {
-    vector<vector<int>> adj;
+    vector<vi> adj;
     edge_cd(adj, [&](int, int) -> void { assert(false); });
   }
   {
-    vector<vector<int>> adj(1);
+    vector<vi> adj(1);
     edge_cd(adj, [&](int, int) -> void { assert(false); });
   }
   for (int n = 2; n <= 7; n++) {
     int num_codes = 1;
-    for (int k = 0; k < n - 2; k++) num_codes *= n;
+    rep(k, 0, n - 2) num_codes *= n;
     // int num_codes = mpow(n, n - 2).x;
-    vector<vector<int>> pruf_codes(num_codes,
-      vector<int>(n - 2));
-    for (int i = 0; i < num_codes; i++) {
+    vector<vi> pruf_codes(num_codes, vi(n - 2));
+    rep(i, 0, num_codes) {
       int val = i;
-      for (int j = 0; j < n - 2; j++) {
+      rep(j, 0, n - 2) {
         int digit = val % n;
         val /= n;
         pruf_codes[i][j] = digit + 1;
       }
     }
-    for (vector<int>& code : pruf_codes) {
+    for (vi& code : pruf_codes) {
       auto edges = pruferCodeToTree(code);
       assert(sz(edges) == n - 1);
-      vector<vector<int>> adj(n);
+      vector<vi> adj(n);
       for (auto [u, v] : edges) {
         u--, v--;
         adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/handmade_tests/fib_matrix_expo.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/fib_matrix_expo.test.cpp
@@ -7,12 +7,12 @@
 const int MOD = 998'244'353;
 #include "../../../kactl/content/data-structures/Matrix.h"
 #include "../../../hackpack-cpp/content/number-theory/ModInt.h"
-void check(int64_t n) {
+void check(ll n) {
   using mat_2_by_2 = Matrix<mi, 2>;
   mat_2_by_2 mat;
   mat.d = {{{{1, 1}}, {{1, 0}}}};
   array<mi, 2> vec = {1, 0};
-  int64_t res = fib(n)[0];
+  ll res = fib(n)[0];
   assert(res == int(((mat ^ n) * vec)[1]));
 }
 int main() {
@@ -29,7 +29,7 @@ int main() {
   assert(fib(3)[0] == 2);
   assert(fib(4)[0] == 3);
   assert(fib(5)[0] == 5);
-  for (int i = 0; i < 500; i++) check(i);
+  rep(i, 0, 500) check(i);
   for (int tests = 1000; tests--;)
     check(rnd(0LL, LLONG_MAX));
   cout << "Hello World\n";

--- a/tests/library_checker_aizu_tests/handmade_tests/functional_graph.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/functional_graph.test.cpp
@@ -5,9 +5,9 @@
 #include "../../../library/graphs/uncommon/functional_graph_processor.hpp"
 // https://github.com/Aeren1564/Algorithms/blob/master/Algorithm_Implementations_Cpp/Graph_Theory/Special_Graphs/functional_graph_processor.sublime-snippet
 struct functional_graph_processor {
-  functional_graph_processor(const vector<int> &next) {
-    init(sz(next));
-    build(next);
+  functional_graph_processor(const vi &nxt) {
+    init(sz(nxt));
+    build(nxt);
   }
   template<class Graph_t>
   functional_graph_processor(const Graph_t &g) {
@@ -33,10 +33,10 @@ struct functional_graph_processor {
     attempt = -1;
   }
   int attempt;
-  vector<int> was, was2;
-  void build(const vector<int> &next) {
+  vi was, was2;
+  void build(const vi &nxt) {
     cycle.clear();
-    for (int i = 0; i < n; i++) {
+    rep(i, 0, n) {
       cycle_id[i] = -1;
       cycle_pos[i] = -1;
       cycle_prev[i] = -1;
@@ -47,11 +47,11 @@ struct functional_graph_processor {
       int v = u;
       while (was[v] != attempt) {
         was[v] = attempt;
-        v = next[v];
+        v = nxt[v];
       }
       if (was2[v] != attempt) {
         int w = v;
-        vector<int> c;
+        vi c;
         while (was2[w] != attempt) {
           was2[w] = attempt;
           cycle_id[w] = sz(cycle);
@@ -59,14 +59,14 @@ struct functional_graph_processor {
           c.push_back(w);
           root_of[w] = w;
           depth[w] = 0;
-          w = next[w];
+          w = nxt[w];
         }
         cycle.push_back(c);
       }
       auto dfs = [&](auto self, int u2) -> void {
         if (was2[u2] == attempt) return;
         was2[u2] = attempt;
-        int v2 = next[u2];
+        int v2 = nxt[u2];
         self(self, v2);
         root_of[u2] = root_of[v2];
         depth[u2] = depth[v2] + 1;
@@ -75,7 +75,7 @@ struct functional_graph_processor {
       dfs(dfs, u);
     }
     for (auto u = 0; u < n; ++u)
-      if (~cycle_pos[u]) cycle_prev[next[u]] = u;
+      if (~cycle_pos[u]) cycle_prev[nxt[u]] = u;
     for (const auto &c : cycle) {
       auto dfs = [&](auto self, int u) -> void {
         size[u] = 1;
@@ -100,36 +100,35 @@ struct functional_graph_processor {
     }
   }
   int n;
-  vector<vector<int>> cycle;
-  vector<int> cycle_id; // id of the cycle it belongs to,
-                        // -1 if not part of one
-  vector<int> cycle_pos; // position in its cycle, -1 if
-                         // not part of one
-  vector<int> cycle_prev; // previous vertex in its cycle,
-                          // -1 if not part of one
-  vector<int> component_size; // size of its weakly
-                              // connected component
-  vector<int> root_of; // first reachable node in a cycle
-  vector<int> depth; // distance to its root
-  vector<vector<int>>
-    abr; // forest of arborescences of reversed edges not
-         // on the cycles
-  vector<int> order; // dfs order of abr
-  vector<int> pos; // pos in the dfs order
-  vector<int> end; // [pos[u], end[u]) denotes the subtree
-  vector<int> size; // size of the subtree in abr
+  vector<vi> cycle;
+  vi cycle_id; // id of the cycle it belongs to,
+               // -1 if not part of one
+  vi cycle_pos; // position in its cycle, -1 if
+                // not part of one
+  vi cycle_prev; // previous vertex in its cycle,
+                 // -1 if not part of one
+  vi component_size; // size of its weakly
+                     // connected component
+  vi root_of; // first reachable node in a cycle
+  vi depth; // distance to its root
+  vector<vi> abr; // forest of arborescences of reversed
+                  // edges not on the cycles
+  vi order; // dfs order of abr
+  vi pos; // pos in the dfs order
+  vi end; // [pos[u], end[u]) denotes the subtree
+  vi size; // size of the subtree in abr
 };
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (int num_tests = 100; num_tests--;) {
     int n = rnd(1, 1000);
-    vector<int> a(n);
-    for (int i = 0; i < n; i++) a[i] = rnd(0, n - 1);
+    vi a(n);
+    rep(i, 0, n) a[i] = rnd(0, n - 1);
     auto [root_of, cycle, childs] = func_graph(a);
     functional_graph_processor fgp(a);
     assert(cycle == fgp.cycle);
     assert(childs == fgp.abr);
-    for (int i = 0; i < n; i++) {
+    rep(i, 0, n) {
       int root =
         cycle[root_of[i].first][root_of[i].second];
       assert(root == fgp.root_of[i]);
@@ -137,7 +136,7 @@ int main() {
       if (root == i) {
         assert(root_of[i].first == fgp.cycle_id[i]);
         assert(root_of[i].second == fgp.cycle_pos[i]);
-        int cyc_len = ssize(cycle[root_of[i].first]);
+        int cyc_len = sz(cycle[root_of[i].first]);
         assert(cycle[root_of[i].first]
                     [(root_of[i].second + 1) % cyc_len] ==
                a[i]);

--- a/tests/library_checker_aizu_tests/handmade_tests/hilbert_mos.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/hilbert_mos.test.cpp
@@ -3,13 +3,13 @@
 #include "../template.hpp"
 #include "../../../library/contest/random.hpp"
 #include "../../../library/data_structures_[l,r)/uncommon/hilbert_mos.hpp"
-const vector<int> di = {1, -1, 0, 0};
-const vector<int> dj = {0, 0, 1, -1};
+const vi di = {1, -1, 0, 0};
+const vi dj = {0, 0, 1, -1};
 void test(int i, int j) {
   ll res = hilbert(i, j);
   int cnt_prev = 0;
   int cnt_next = 0;
-  for (int k = 0; k < 4; k++) {
+  rep(k, 0, 4) {
     int to_i = i + di[k];
     int to_j = j + dj[k];
     if (to_i >= 0 && to_j >= 0) {
@@ -23,8 +23,7 @@ void test(int i, int j) {
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);
-  for (int i = 0; i < 3000; i++)
-    for (int j = 0; j < 3000; j++) test(i, j);
+  rep(i, 0, 3000) rep(j, 0, 3000) test(i, j);
   for (int iter = 50000; iter--;) {
     int i = rnd(0, 1'000'000'000);
     int j = rnd(0, 1'000'000'000);

--- a/tests/library_checker_aizu_tests/handmade_tests/kd_bit.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/kd_bit.test.cpp
@@ -5,17 +5,16 @@
 #include "../../../library/data_structures_[l,r)/bit_uncommon/kd_bit.hpp"
 int main() {
   cin.tie(0)->sync_with_stdio(0);
-  for (int num_tests = 0; num_tests < 100; num_tests++) {
+  rep(num_tests, 0, 100) {
     int n = rnd(1, 100);
     int m = rnd(1, 100);
     KD_BIT<2> bit(n, m);
     vector<vector<ll>> a(n, vector<ll>(m, 0));
-    for (int i = 0; i < n; i++)
-      for (int j = 0; j < m; j++) {
-        a[i][j] = rnd(INT_MIN, INT_MAX);
-        bit.update(i, j, a[i][j]);
-      }
-    for (int events = 0; events < 100; events++) {
+    rep(i, 0, n) rep(j, 0, m) {
+      a[i][j] = rnd(INT_MIN, INT_MAX);
+      bit.update(i, j, a[i][j]);
+    }
+    rep(events, 0, 100) {
       if (events % 2 == 0) {
         int i = rnd(0, n - 1);
         int j = rnd(0, m - 1);
@@ -30,26 +29,23 @@ int main() {
         if (i1 > i2) swap(i1, i2);
         if (j1 > j2) swap(j1, j2);
         ll naive = 0;
-        for (int i = i1; i < i2; i++)
-          for (int j = j1; j < j2; j++) naive += a[i][j];
+        rep(i, i1, i2) rep(j, j1, j2) naive += a[i][j];
         assert(naive == bit.query(i1, i2, j1, j2));
       }
     }
   }
-  for (int num_tests = 0; num_tests < 100; num_tests++) {
+  rep(num_tests, 0, 100) {
     int n = rnd(1, 100);
     int m = rnd(1, 100);
     int l = rnd(1, 100);
     KD_BIT<3> bit(n, m, l);
     vector<vector<vector<ll>>> a(n,
       vector<vector<ll>>(m, vector<ll>(l, 0)));
-    for (int i = 0; i < n; i++)
-      for (int j = 0; j < m; j++)
-        for (int k = 0; k < l; k++) {
-          a[i][j][k] = rnd(INT_MIN, INT_MAX);
-          bit.update(i, j, k, a[i][j][k]);
-        }
-    for (int events = 0; events < 100; events++) {
+    rep(i, 0, n) rep(j, 0, m) rep(k, 0, l) {
+      a[i][j][k] = rnd(INT_MIN, INT_MAX);
+      bit.update(i, j, k, a[i][j][k]);
+    }
+    rep(events, 0, 100) {
       if (events % 2 == 0) {
         int i = rnd(0, n - 1);
         int j = rnd(0, m - 1);
@@ -68,10 +64,8 @@ int main() {
         if (j1 > j2) swap(j1, j2);
         if (k1 > k2) swap(k1, k2);
         ll naive = 0;
-        for (int i = i1; i < i2; i++)
-          for (int j = j1; j < j2; j++)
-            for (int k = k1; k < k2; k++)
-              naive += a[i][j][k];
+        rep(i, i1, i2) rep(j, j1, j2) rep(k, k1, k2)
+          naive += a[i][j][k];
         assert(naive == bit.query(i1, i2, j1, j2, k1, k2));
       }
     }

--- a/tests/library_checker_aizu_tests/handmade_tests/kth_par.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/kth_par.test.cpp
@@ -6,10 +6,10 @@
 #include "../../../library/trees/uncommon/linear_kth_par.hpp"
 int main() {
   for (int n = 1; n <= 100; n++) {
-    for (int param = 1; param < 20; param++) {
-      vector<int> par(n);
-      vector<vector<int>> adj(n);
-      for (int i = 1; i < n; i++) {
+    rep(param, 1, 20) {
+      vi par(n);
+      vector<vi> adj(n);
+      rep(i, 1, n) {
         if (param == 19) par[i] = rnd(0, i - 1);
         else par[i] = rnd(max(0, i - param), i - 1);
         adj[par[i]].push_back(i);
@@ -17,7 +17,7 @@ int main() {
       }
       hagerup<2> hagerup_kth_par(adj);
       linear_kth_par lin_kth_par(adj);
-      for (int i = 0; i < n; i++) {
+      rep(i, 0, n) {
         for (int k = 0, kth_parent_naive = i;
           k <= hagerup_kth_par.d[i];
           k++, kth_parent_naive = par[kth_parent_naive]) {

--- a/tests/library_checker_aizu_tests/handmade_tests/manacher.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/manacher.test.cpp
@@ -11,7 +11,7 @@ int main() {
       string s(n, 'a');
       if (n == 0 || rnd<int>(0, 1) == 0) {
         int mx_char = rnd<int>(0, 5);
-        generate(begin(s), end(s), [&]() {
+        ranges::generate(s, [&]() {
           return char('a' + rnd<int>(0, mx_char));
         });
       } else {
@@ -29,20 +29,17 @@ int main() {
                 is_pal_naive[l + 1][r - 1]);
         }
       }
-      for (int i = 0; i < n; i++)
-        for (int j = i; j < n; j++)
-          assert(
-            pq.is_pal(i, j) == is_pal_naive[i][j + 1]);
-      vector<int> longest(longest_from_index(pq));
-      for (int l = 0; l < n; l++) {
+      rep(i, 0, n) rep(j, i, n)
+        assert(pq.is_pal(i, j) == is_pal_naive[i][j + 1]);
+      vi longest(longest_from_index(pq));
+      rep(l, 0, n) {
         bool seen_pal = 0;
         for (int r = n; r >= l; r--) {
           seen_pal |= is_pal_naive[l][r];
           assert((longest[l] + 1 >= r) == seen_pal);
         }
       }
-      vector<vector<int>> count_pals_naive(n + 1,
-        vector<int>(n + 1, 0));
+      vector<vi> count_pals_naive(n + 1, vi(n + 1, 0));
       for (int l = 0; l + 1 <= n; l++)
         count_pals_naive[l][l + 1] = 1;
       for (int len = 2; len <= n; len++) {
@@ -55,8 +52,7 @@ int main() {
             count_pals_naive[l + 1][r - 1];
         }
       }
-      vector<vector<int>> longest_pal(n + 1,
-        vector<int>(n + 1, 0));
+      vector<vi> longest_pal(n + 1, vi(n + 1, 0));
       longest_pal_query lp(s);
       for (int len = 1; len <= n; len++) {
         for (int l = 0; l + len <= n; l++) {

--- a/tests/library_checker_aizu_tests/handmade_tests/merge_st_and_wavelet.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/merge_st_and_wavelet.test.cpp
@@ -12,8 +12,8 @@ int main() {
       int minn = rnd<int>(-1000, 1000);
       int maxn = rnd<int>(-1000, 1000);
       if (minn > maxn) swap(minn, maxn);
-      vector<int> arr(n);
-      generate(begin(arr), end(arr),
+      vi arr(n);
+      ranges::generate(arr,
         [&]() { return rnd<int>(minn, maxn); });
       merge_sort_tree mst(arr);
       vector<ll> arr_shifted(n);

--- a/tests/library_checker_aizu_tests/handmade_tests/mobius.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/mobius.test.cpp
@@ -7,7 +7,7 @@ int main() {
 #include "../../../library/math/prime_sieve/mobius.hpp"
 #include "../../../library/math/prime_sieve/is_prime.hpp"
   assert(is_prime(2));
-  for (int i = 1; i < sz(mobius); i++) {
+  rep(i, 1, sz(mobius)) {
     int val = i;
     map<ull, int> factors;
     for (auto prime_factor : factor(val))

--- a/tests/library_checker_aizu_tests/handmade_tests/mod_division.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/mod_division.test.cpp
@@ -7,8 +7,8 @@
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (mod = 1; mod < 500; mod++) {
-    for (int x = 0; x < mod; x++) {
-      for (int y = 0; y < mod; y++) {
+    rep(x, 0, mod) {
+      rep(y, 0, mod) {
         if (gcd(y, mod) == 1) {
           int quotient = mod_div(x, y);
           assert(1LL * quotient * y % mod == x);

--- a/tests/library_checker_aizu_tests/handmade_tests/n_choose_k.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/n_choose_k.test.cpp
@@ -9,7 +9,7 @@ int main() {
 #define mod mod_2
 #include "../../../library/math/n_choose_k/pascals_identity.hpp"
 #undef mod
-  for (int i = 0; i < sz(ch); i++) {
+  rep(i, 0, sz(ch)) {
     assert(ch[i][0] == 1 && end(ch[i])[-1] == 1);
     assert(lucas(i, -1) == 0);
     assert(c_small_k(i, -1) == 0);
@@ -20,13 +20,13 @@ int main() {
     assert(lucas(i, i - 1) == i % mod);
     if (i - 1 < mod)
       assert(c_small_k(i, i - 1) == i % mod);
-    for (int j = 0; j < sz(ch[i]); j++) {
+    rep(j, 0, sz(ch[i])) {
       assert(lucas(i, j) == ch[i][j]);
       if (j < mod) assert(c_small_k(i, j) == ch[i][j]);
     }
   }
   for (int tests = 100'000; tests--;) {
-    auto n = rnd(int64_t(-1e18), int64_t(1e18));
+    auto n = rnd(ll(-1e18), ll(1e18));
     auto k = rnd(-mod, mod - 1);
     assert(lucas(n, k) == c_small_k(n, k));
   }

--- a/tests/library_checker_aizu_tests/handmade_tests/permutation_tree_small.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/permutation_tree_small.test.cpp
@@ -6,11 +6,11 @@
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (int n = 1; n <= 8; n++) {
-    vector<int> a(n);
-    iota(begin(a), end(a), 0);
+    vi a(n);
+    iota(all(a), 0);
     do {
       perm_tree pt = perm_tree_asserts(a);
-    } while (next_permutation(begin(a), end(a)));
+    } while (next_permutation(all(a)));
   }
   cout << "Hello World\n";
   return 0;

--- a/tests/library_checker_aizu_tests/handmade_tests/rmq_small_n.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/rmq_small_n.test.cpp
@@ -4,11 +4,11 @@
 #include "../../../library/contest/random.hpp"
 #include "../../../library/data_structures_[l,r)/rmq.hpp"
 #include "../../../library/data_structures_[l,r]/linear_rmq.hpp"
-void test_all_subarrays(const vector<int>& a) {
+void test_all_subarrays(const vi& a) {
   auto n = sz(a);
   RMQ rmq(a, [](auto x, auto y) { return min(x, y); });
   linear_rmq lin_rmq(a, less());
-  for (int l = 0; l < n; l++) {
+  rep(l, 0, n) {
     for (int r = l + 1; r <= n; r++) {
       int idx_min = lin_rmq.idx(l, r - 1);
       assert(l <= idx_min && idx_min < r);
@@ -19,17 +19,16 @@ void test_all_subarrays(const vector<int>& a) {
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   for (int n = 1; n <= 8; n++) {
-    vector<int> perm(n);
-    iota(begin(perm), end(perm), 0);
+    vi perm(n);
+    iota(all(perm), 0);
     do {
       test_all_subarrays(perm);
-    } while (next_permutation(begin(perm), end(perm)));
+    } while (next_permutation(all(perm)));
   }
   for (int n = 1; n <= 100; n++) {
-    for (int times = 0; times < 40; times++) {
-      vector<int> a(n);
-      for (int i = 0; i < n; i++)
-        a[i] = rnd<int>(INT_MIN, INT_MAX);
+    rep(times, 0, 40) {
+      vi a(n);
+      rep(i, 0, n) a[i] = rnd<int>(INT_MIN, INT_MAX);
       test_all_subarrays(a);
     }
   }

--- a/tests/library_checker_aizu_tests/handmade_tests/sa_find_subarray.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/sa_find_subarray.test.cpp
@@ -9,16 +9,16 @@ int main() {
     for (int tests = 10; tests--;) {
       string s(n, 'a');
       int mx_char = rnd<int>(0, 5);
-      generate(begin(s), end(s), [&]() {
+      ranges::generate(s, [&]() {
         return char('a' + rnd<int>(0, mx_char));
       });
       auto [sa, sa_inv, lcp] = get_sa(s, 256);
       sa_query lq(s, sa, sa_inv, lcp);
-      for (int i = 0; i < n; i++) {
+      rep(i, 0, n) {
         for (int j = i; j <= n; j++) {
           auto [sa_le, sa_ri, s_l, s_r] =
             lq.find_substrs_concated({{i, j}});
-          pair<int, int> short_res = lq.find_substr(i, j);
+          pii short_res = lq.find_substr(i, j);
           assert(sa_le == short_res.first &&
                  sa_ri == short_res.second);
           assert(s.substr(i, j - i) ==
@@ -30,7 +30,7 @@ int main() {
           if (i < n)
             assert(0 <= sa_le && sa_le <= lq.sa_inv[i] &&
                    lq.sa_inv[i] < sa_ri && sa_ri <= n);
-          for (int idx = sa_le; idx < sa_ri; idx++)
+          rep(idx, sa_le, sa_ri)
             assert(s.substr(lq.sa[idx], j - i) ==
                    s.substr(i, j - i));
           assert(sa_le == 0 ||
@@ -41,8 +41,8 @@ int main() {
                             s.substr(i, j - i));
         }
       }
-      for (int i = 0; i < n; i++) {
-        for (int k = 0; k < n; k++) {
+      rep(i, 0, n) {
+        rep(k, 0, n) {
           for (int j = i; j <= n; j++) {
             for (int l = k; l <= n; l++) {
               int cmp_val = lq.cmp_substrs(i, j, k, l);

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
@@ -51,7 +51,7 @@ int main() {
       else assert(cur_le == prv_ri);
     }
     ranges::sort(rngs);
-    assert(unique(all(rngs)) == end(rngs));
+    assert(empty(ranges::unique(rngs)));
     reset();
     assert(
       pos == rv(rev.find_last(rv(r - 1), rv(l) + 1, f)));
@@ -67,7 +67,7 @@ int main() {
       else assert(prv_le == cur_ri);
     }
     ranges::sort(rngs);
-    assert(unique(all(rngs)) == end(rngs));
+    assert(empty(ranges::unique(rngs)));
   }
   cout << "Hello World\n";
   return 0;

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
@@ -51,7 +51,7 @@ int main() {
       else assert(cur_le == prv_ri);
     }
     ranges::sort(rngs);
-    assert(empty(ranges::unique(rngs)));
+    assert(unique(all(rngs)) == end(rngs));
     reset();
     assert(
       pos == rv(rev.find_last(rv(r - 1), rv(l) + 1, f)));
@@ -67,7 +67,7 @@ int main() {
       else assert(prv_le == cur_ri);
     }
     ranges::sort(rngs);
-    assert(empty(ranges::unique(rngs)));
+    assert(unique(all(rngs)) == end(rngs));
   }
   cout << "Hello World\n";
   return 0;

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find.test.cpp
@@ -10,10 +10,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   BIT bit(mx_n);
   seg_tree seg(mx_n), rev(mx_n);
-  for (int i = 0; i < mx_n; i++)
-    bit.update(i, 1), seg.update(i, i + 1, 1),
-      rev.update(i, i + 1, 1);
-  for (int q = 0; q < 100'000; q++) {
+  rep(i, 0, mx_n) bit.update(i, 1),
+    seg.update(i, i + 1, 1), rev.update(i, i + 1, 1);
+  rep(q, 0, 100'000) {
     int i = rnd(0, mx_n - 1);
     int add = rnd(0, 100'000);
     bit.update(i, add);
@@ -21,15 +20,15 @@ int main() {
     rev.update(rv(i), rv(i) + 1, add);
     int l = rnd(0, mx_n - 1);
     int r = rnd(l + 1, mx_n);
-    int64_t in_tree = seg.query(l, r);
-    auto sum = rnd<int64_t>(1, in_tree);
-    int64_t need;
+    ll in_tree = seg.query(l, r);
+    auto sum = rnd<ll>(1, in_tree);
+    ll need;
     vector<array<int, 3>> rngs;
     auto reset = [&] {
       need = sum;
       rngs = {};
     };
-    auto f = [&](int64_t x, int tl, int tr) -> bool {
+    auto f = [&](ll x, int tl, int tr) -> bool {
       if (x < need) {
         rngs.push_back({tl, tr, 0});
         need -= x;
@@ -45,14 +44,14 @@ int main() {
     assert(rngs[0][0] == l);
     for (auto [tl, tr, _] : rngs)
       assert(l <= tl && tl < tr && tr <= r);
-    for (int it = 1; it < sz(rngs); it++) {
+    rep(it, 1, sz(rngs)) {
       auto [prv_le, prv_ri, prv] = rngs[it - 1];
       auto [cur_le, cur_ri, cur] = rngs[it];
       if (prv) assert(cur_le == prv_le && cur_ri < prv_ri);
       else assert(cur_le == prv_ri);
     }
-    sort(begin(rngs), end(rngs));
-    assert(unique(begin(rngs), end(rngs)) == end(rngs));
+    ranges::sort(rngs);
+    assert(empty(ranges::unique(rngs)));
     reset();
     assert(
       pos == rv(rev.find_last(rv(r - 1), rv(l) + 1, f)));
@@ -61,14 +60,14 @@ int main() {
     for (auto [tl, tr, _] : rngs)
       assert(
         rv(r - 1) <= tl && tl < tr && tr <= rv(l) + 1);
-    for (int it = 1; it < sz(rngs); it++) {
+    rep(it, 1, sz(rngs)) {
       auto [prv_le, prv_ri, prv] = rngs[it - 1];
       auto [cur_le, cur_ri, cur] = rngs[it];
       if (prv) assert(cur_ri == prv_ri && cur_le > prv_le);
       else assert(prv_le == cur_ri);
     }
-    sort(begin(rngs), end(rngs));
-    assert(unique(begin(rngs), end(rngs)) == end(rngs));
+    ranges::sort(rngs);
+    assert(empty(ranges::unique(rngs)));
   }
   cout << "Hello World\n";
   return 0;

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find_small.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_find_small.test.cpp
@@ -8,14 +8,14 @@ int main() {
   for (int iters = 0; iters < 100; ++iters) {
     int n = 1'000;
     seg_tree seg(n);
-    vector<int> a(n);
-    for (int q = 0; q < 1'000; q++) {
+    vi a(n);
+    rep(q, 0, 1'000) {
       if (rnd(0, 1) == 0) {
         int l = rnd(0, n - 1);
         int r = rnd(l + 1, n);
         int diff = rnd(0, 10);
         seg.update(l, r, diff);
-        for (int i = l; i < r; i++) a[i] += diff;
+        rep(i, l, r) a[i] += diff;
       } else {
         int l = rnd(0, n - 1);
         int r = rnd(l + 1, n);
@@ -37,7 +37,7 @@ int main() {
           }
         }
         int st_walk_sum;
-        auto f = [&](int64_t x, int, int) -> bool {
+        auto f = [&](ll x, int, int) -> bool {
           if (st_walk_sum + x <= target_sum) {
             st_walk_sum += x;
             return 0;

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_midpoint.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_midpoint.test.cpp
@@ -4,7 +4,7 @@
 #include "../../../library/data_structures_[l,r)/seg_tree_midpoint.hpp"
 int main() {
   cin.tie(0)->sync_with_stdio(0);
-  for (int n = 1; n < 5000; n++) {
+  rep(n, 1, 5000) {
     auto dfs = [&](auto&& self, int tl, int tr,
                  int v) -> void {
       assert((v >= n) == ((tr - tl) == 1));

--- a/tests/library_checker_aizu_tests/handmade_tests/seg_tree_midpoint.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/seg_tree_midpoint.test.cpp
@@ -2,6 +2,7 @@
   "https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_A"
 #include "../template.hpp"
 #include "../../../library/data_structures_[l,r)/seg_tree_midpoint.hpp"
+int lg(int x) { return bit_width(x + 0u) - 1; }
 int main() {
   cin.tie(0)->sync_with_stdio(0);
   rep(n, 1, 5000) {
@@ -9,8 +10,8 @@ int main() {
                  int v) -> void {
       assert((v >= n) == ((tr - tl) == 1));
       if (v >= n) { // leaf node
-        const int depth_leaf = __lg(v),
-                  max_depth = __lg(2 * n - 1);
+        const int depth_leaf = lg(v),
+                  max_depth = lg(2 * n - 1);
         if (tl == 0) { // left-most leaf
           assert(v == (1 << max_depth));
           assert(depth_leaf == max_depth);
@@ -25,7 +26,7 @@ int main() {
         if (((tr - tl) & (tr - tl - 1)) == 0)
           assert(split(tl, tr) == (tl + tr) / 2);
         {
-          int pow_2 = 1 << __lg(tr - tl);
+          int pow_2 = bit_floor(tr - tl + 0u);
           if (tl + pow_2 < tr - pow_2 / 2) {
             assert(pow_2 != tr - tl);
             assert(pow_2 / 2 < tr - tl - pow_2 &&
@@ -33,9 +34,9 @@ int main() {
             assert(
               pow_2 <= 2 * (tr - tl - pow_2) - 1 &&
               2 * (tr - tl - pow_2) - 1 < 2 * pow_2 - 1);
-            assert(__lg(pow_2) ==
-                     __lg(2 * ((tr - tl) - pow_2) - 1) &&
-                   __lg(pow_2) == __lg(2 * pow_2 - 1));
+            assert(lg(pow_2) ==
+                     lg(2 * ((tr - tl) - pow_2) - 1) &&
+                   lg(pow_2) == lg(2 * pow_2 - 1));
           } else if (pow_2 < tr - tl) {
             assert(pow_2 / 2 < tr - tl - pow_2 / 2 &&
                    tr - tl - pow_2 / 2 <= pow_2);
@@ -43,12 +44,12 @@ int main() {
               pow_2 <= 2 * ((tr - tl) - pow_2 / 2) - 1 &&
               2 * ((tr - tl) - pow_2 / 2) - 1 <=
                 2 * pow_2 - 1);
-            assert(__lg(2 * (tr - tl - pow_2 / 2) - 1) ==
-                   __lg(2 * pow_2 - 1));
-            assert(__lg(2 * ((tr - tl) - pow_2 / 2) - 1) ==
-                   __lg(pow_2));
-            assert(__lg(pow_2) ==
-                   1 + __lg(2 * (pow_2 / 2) - 1));
+            assert(lg(2 * (tr - tl - pow_2 / 2) - 1) ==
+                   lg(2 * pow_2 - 1));
+            assert(lg(2 * ((tr - tl) - pow_2 / 2) - 1) ==
+                   lg(pow_2));
+            assert(
+              lg(pow_2) == 1 + lg(2 * (pow_2 / 2) - 1));
           }
         }
         int tm = split(tl, tr);

--- a/tests/library_checker_aizu_tests/handmade_tests/xor_basis_walk.test.cpp
+++ b/tests/library_checker_aizu_tests/handmade_tests/xor_basis_walk.test.cpp
@@ -5,13 +5,13 @@
 #include "../../../library/math/matrix_related/xor_basis_ordered.hpp"
 vector<bitset<18>> get_all(
   const vector<bitset<18>>& basis) {
-  int n = ssize(basis);
+  int n = sz(basis);
   vector<bitset<18>> span;
-  for (int mask = 0; mask < (1 << n); mask++) {
+  rep(mask, 0, (1 << n)) {
     bitset<18> curr_xor;
     assert(curr_xor.none());
-    for (int bit = 0; bit < n; bit++)
-      if ((mask >> bit) & 1) curr_xor ^= basis[bit];
+    rep(bit, 0, n) if ((mask >> bit) & 1)
+      curr_xor ^= basis[bit];
     span.push_back(curr_xor);
   }
   ranges::sort(span, {}, [&](const bitset<18>& x) -> long {
@@ -21,23 +21,23 @@ vector<bitset<18>> get_all(
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);
-  for (int num_tests = 0; num_tests < 100; num_tests++) {
+  rep(num_tests, 0, 100) {
     xor_basis<18> b;
     int n = rnd(1, 16);
     vector<bitset<18>> naive_basis;
-    for (int i = 0; i < n; i++) {
+    rep(i, 0, n) {
       bitset<18> val = rnd(0, (1 << n) - 1);
       if (b.insert(val)) naive_basis.push_back(val);
       assert(b.npivot + b.nfree == i + 1);
     }
-    assert(ssize(naive_basis) == b.npivot);
+    assert(sz(naive_basis) == b.npivot);
     vector<bitset<18>> fast_basis;
-    for (int i = 0; i < 18; i++)
-      if (b.basis[i][i]) fast_basis.push_back(b.basis[i]);
+    rep(i, 0, 18) if (b.basis[i][i])
+      fast_basis.push_back(b.basis[i]);
     vector<bitset<18>> naive_span = get_all(naive_basis);
     vector<bitset<18>> fast_span = get_all(fast_basis);
     assert(naive_span == fast_span);
-    for (int i = 0; i < ssize(naive_span); i++) {
+    rep(i, 0, sz(naive_span)) {
       bitset<18> k = i;
       assert(naive_span[i] == b.walk(k));
     }

--- a/tests/library_checker_aizu_tests/loops/chooses.test.cpp
+++ b/tests/library_checker_aizu_tests/loops/chooses.test.cpp
@@ -9,8 +9,8 @@ int main() {
 #include "../../../library/loops/chooses.hpp"
   {
     cout << mask << ':';
-    for (int bit = 0; bit < n; bit++)
-      if ((mask >> bit) & 1) cout << ' ' << bit;
+    rep(bit, 0, n) if ((mask >> bit) & 1) cout << ' '
+                                               << bit;
     cout << '\n';
   }
   return 0;

--- a/tests/library_checker_aizu_tests/loops/quotients.test.cpp
+++ b/tests/library_checker_aizu_tests/loops/quotients.test.cpp
@@ -3,11 +3,11 @@
 #include "../template.hpp"
 int main() {
   cin.tie(0)->sync_with_stdio(0);
-  int64_t n;
+  ll n;
   cin >> n;
-  vector<int64_t> quots;
+  vector<ll> quots;
   {
-    int64_t prev_ri = 0;
+    ll prev_ri = 0;
 #include "../../../library/loops/quotients.hpp"
     {
       assert(n / l == n / r);

--- a/tests/library_checker_aizu_tests/loops/submasks.test.cpp
+++ b/tests/library_checker_aizu_tests/loops/submasks.test.cpp
@@ -6,22 +6,22 @@ int main() {
   int n, k;
   cin >> n >> k;
   int mask = 0;
-  for (int i = 0; i < k; i++) {
+  rep(i, 0, k) {
     int bit;
     cin >> bit;
     mask |= 1 << bit;
   }
   cout << 0 << ':' << '\n';
-  vector<int> sb_msks;
+  vi sb_msks;
   {
 #include "../../../library/loops/submasks.hpp"
     sb_msks.push_back(submask);
   }
-  reverse(begin(sb_msks), end(sb_msks));
+  ranges::reverse(sb_msks);
   for (auto submask : sb_msks) {
     cout << submask << ':';
-    for (int bit = 0; bit < n; bit++)
-      if ((submask >> bit) & 1) cout << ' ' << bit;
+    rep(bit, 0, n) if ((submask >> bit) & 1) cout << ' '
+                                                  << bit;
     cout << '\n';
   }
   return 0;

--- a/tests/library_checker_aizu_tests/loops/supermasks.test.cpp
+++ b/tests/library_checker_aizu_tests/loops/supermasks.test.cpp
@@ -6,20 +6,20 @@ int main() {
   int n, k;
   cin >> n >> k;
   int mask = 0;
-  for (int i = 0; i < k; i++) {
+  rep(i, 0, k) {
     int bit;
     cin >> bit;
     mask |= 1 << bit;
   }
-  vector<int> sup_msks;
+  vi sup_msks;
   {
 #include "../../../library/loops/supermasks.hpp"
     sup_msks.push_back(supermask);
   }
   for (auto supermask : sup_msks) {
     cout << supermask << ':';
-    for (int bit = 0; bit < n; bit++)
-      if ((supermask >> bit) & 1) cout << ' ' << bit;
+    rep(bit, 0, n) if ((supermask >> bit) & 1) cout << ' '
+                                                    << bit;
     cout << '\n';
   }
   return 0;

--- a/tests/library_checker_aizu_tests/math/binary_matrix_mult.test.cpp
+++ b/tests/library_checker_aizu_tests/math/binary_matrix_mult.test.cpp
@@ -8,19 +8,19 @@ int main() {
   cin >> n >> m >> k;
   const int mx_n = 1 << 12;
   array<bitset<mx_n>, mx_n> m1, m2;
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     string row;
     cin >> row;
-    for (int j = 0; j < m; j++) m1[i][j] = row[j] - '0';
+    rep(j, 0, m) m1[i][j] = row[j] - '0';
   }
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     string row;
     cin >> row;
-    for (int j = 0; j < k; j++) m2[i][j] = row[j] - '0';
+    rep(j, 0, k) m2[i][j] = row[j] - '0';
   }
   auto prod = m1 * m2;
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < k; j++) cout << prod[i][j];
+  rep(i, 0, n) {
+    rep(j, 0, k) cout << prod[i][j];
     cout << '\n';
   }
   return 0;

--- a/tests/library_checker_aizu_tests/math/count_paths.test.cpp
+++ b/tests/library_checker_aizu_tests/math/count_paths.test.cpp
@@ -12,10 +12,10 @@
 #undef mod
 #undef modpow
 ll modpow(ll b, ll e) {
-  ll ans = 1;
+  ll res = 1;
   for (; e; b = b * b % 998'244'353, e /= 2)
-    if (e & 1) ans = ans * b % 998'244'353;
-  return ans;
+    if (e & 1) res = res * b % 998'244'353;
+  return res;
 }
 #include "../../../library/math/count_paths/count_paths_triangle.hpp"
 ll count_between_two_sequences(const vl& a, const vl& b) {
@@ -26,7 +26,7 @@ ll count_between_two_sequences(const vl& a, const vl& b) {
     int j = i;
     {
       vl h(b[i] - a[i]);
-      for (int num = a[i]; num < b[i]; num++) {
+      rep(num, a[i], b[i]) {
         while (j < n && a[j] <= num) j++;
         h[num - a[i]] = j - i;
       }
@@ -36,7 +36,7 @@ ll count_between_two_sequences(const vl& a, const vl& b) {
     }
     {
       vl h(j - i);
-      for (int k = i; k < j; k++) h[k - i] = b[k] - b[i];
+      rep(k, i, j) h[k - i] = b[k] - b[i];
       if (h.back() == 0) break;
       dp = divide_and_conquer(h, dp);
       if (j < n)
@@ -52,12 +52,12 @@ int main() {
   int n, m;
   cin >> n >> m;
   vl a(n), b(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  for (int i = 0; i < n; i++) cin >> b[i];
-  for (int i = 1; i < n; i++) a[i] = max(a[i], a[i - 1]);
+  rep(i, 0, n) cin >> a[i];
+  rep(i, 0, n) cin >> b[i];
+  rep(i, 1, n) a[i] = max(a[i], a[i - 1]);
   for (int i = n - 2; i >= 0; i--)
     b[i] = min(b[i], b[i + 1]);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     if (a[i] >= b[i]) {
       cout << 0 << '\n';
       return 0;

--- a/tests/library_checker_aizu_tests/math/matrix_determinant.test.cpp
+++ b/tests/library_checker_aizu_tests/math/matrix_determinant.test.cpp
@@ -6,9 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> matrix(n, vector<int>(n));
-  for (int i = 0; i < n; i++)
-    for (int j = 0; j < n; j++) cin >> matrix[i][j];
+  vector<vi> matrix(n, vi(n));
+  rep(i, 0, n) rep(j, 0, n) cin >> matrix[i][j];
   auto [rank, det] = row_reduce(matrix, n);
   cout << det << '\n';
   return 0;

--- a/tests/library_checker_aizu_tests/math/matrix_mult.test.cpp
+++ b/tests/library_checker_aizu_tests/math/matrix_mult.test.cpp
@@ -17,14 +17,12 @@ int main() {
   int n, m, k;
   cin >> n >> m >> k;
   vector<vector<mi>> m1(n, vector<mi>(m));
-  for (int i = 0; i < n; i++)
-    for (int j = 0; j < m; j++) cin >> m1[i][j];
+  rep(i, 0, n) rep(j, 0, m) cin >> m1[i][j];
   vector<vector<mi>> m2(m, vector<mi>(k));
-  for (int i = 0; i < m; i++)
-    for (int j = 0; j < k; j++) cin >> m2[i][j];
+  rep(i, 0, m) rep(j, 0, k) cin >> m2[i][j];
   auto prod = m1 * m2;
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < k; j++) cout << prod[i][j] << " ";
+  rep(i, 0, n) {
+    rep(j, 0, k) cout << prod[i][j] << " ";
     cout << '\n';
   }
   return 0;

--- a/tests/library_checker_aizu_tests/math/n_choose_k.test.cpp
+++ b/tests/library_checker_aizu_tests/math/n_choose_k.test.cpp
@@ -25,7 +25,7 @@ int main() {
       assert(C(-k, n) == 0);
     }
   }
-  for (int i = 0; i < sz(t); i++) {
+  rep(i, 0, sz(t)) {
     if (i) assert(i * t[i].inv % mod == 1);
     assert(t[i].fact * t[i].inv_fact % mod == 1);
   }

--- a/tests/library_checker_aizu_tests/math/num_subsequences.test.cpp
+++ b/tests/library_checker_aizu_tests/math/num_subsequences.test.cpp
@@ -7,8 +7,8 @@ int main() {
   const int mod = 998244353;
   int n;
   cin >> n;
-  vector<int> arr(n);
-  for (int i = 0; i < n; i++) cin >> arr[i];
+  vi arr(n);
+  rep(i, 0, n) cin >> arr[i];
   cout << (num_subsequences(arr, mod) - 1 + mod) % mod
        << '\n';
   return 0;

--- a/tests/library_checker_aizu_tests/math/prime_sieve.test.cpp
+++ b/tests/library_checker_aizu_tests/math/prime_sieve.test.cpp
@@ -6,8 +6,7 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
 #include "../../../library/math/prime_sieve/calc_sieve.hpp"
 #include "../../../library/math/prime_sieve/is_prime.hpp"
-  for (int i = 1; i < sz(sieve); i++)
-    assert(isPrime(i) == is_prime(i));
+  rep(i, 1, sz(sieve)) assert(isPrime(i) == is_prime(i));
   {
 #define sieve linear_sieve
 #include "../../../library/math/prime_sieve/calc_linear_sieve.hpp"
@@ -20,17 +19,17 @@ int main() {
   while (n--) {
     int num;
     cin >> num;
-    map<int, int> curr;
+    map<int, int> cur;
     {
       int prev_prime = -1;
 #include "../../../library/math/prime_sieve/get_prime_factors.hpp"
       {
         assert(p >= prev_prime);
         prev_prime = p;
-        curr[p]++;
+        cur[p]++;
       }
     }
-    for (auto [p, e] : curr)
+    for (auto [p, e] : cur)
       prime_to_max_exponent[p] =
         max(prime_to_max_exponent[p], e);
   }

--- a/tests/library_checker_aizu_tests/math/solve_linear_mod.test.cpp
+++ b/tests/library_checker_aizu_tests/math/solve_linear_mod.test.cpp
@@ -6,11 +6,10 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, m;
   cin >> n >> m;
-  vector<vector<int>> mat(n, vector<int>(m));
-  for (int i = 0; i < n; i++)
-    for (int j = 0; j < m; j++) cin >> mat[i][j];
-  vector<int> b(n);
-  for (int i = 0; i < n; i++) cin >> b[i];
+  vector<vi> mat(n, vi(m));
+  rep(i, 0, n) rep(j, 0, m) cin >> mat[i][j];
+  vi b(n);
+  rep(i, 0, n) cin >> b[i];
   solve_linear_mod info(mat, b);
   assert(info.rank <= min(n, m));
   if (empty(info.sol)) {
@@ -20,19 +19,18 @@ int main() {
   cout << m - info.rank << '\n';
   for (int val : info.sol) cout << val << " ";
   cout << '\n';
-  vector<int> pivot(m, -1);
+  vi pivot(m, -1);
   for (int i = 0, j = 0; i < info.rank; i++) {
     while (mat[i][j] == 0) j++;
     pivot[j] = i;
   }
-  for (int j = 0; j < m; j++)
-    if (pivot[j] == -1) {
-      vector<int> x(m, 0);
-      x[j] = mod - 1;
-      for (int k = 0; k < j; k++)
-        if (pivot[k] != -1) x[k] = mat[pivot[k]][j];
-      for (int k = 0; k < m; k++) cout << x[k] << " ";
-      cout << '\n';
-    }
+  rep(j, 0, m) if (pivot[j] == -1) {
+    vi x(m, 0);
+    x[j] = mod - 1;
+    rep(k, 0, j) if (pivot[k] != -1)
+      x[k] = mat[pivot[k]][j];
+    rep(k, 0, m) cout << x[k] << " ";
+    cout << '\n';
+  }
   return 0;
 }

--- a/tests/library_checker_aizu_tests/math/xor_basis_intersection.test.cpp
+++ b/tests/library_checker_aizu_tests/math/xor_basis_intersection.test.cpp
@@ -16,7 +16,7 @@ void check_condition_unordered(const basis& b) {
 }
 void check_condition_ordered(const xor_basis<30>& basis2) {
   bitset<30> or_bits2;
-  for (int i = 0; i < 30; i++) {
+  rep(i, 0, 30) {
     assert(basis2.basis[i].none() ||
            bit_floor(basis2.basis[i].to_ulong()) ==
              (1ULL << i));
@@ -34,9 +34,8 @@ int main() {
     cin >> n;
     basis basis1;
     xor_basis<30> basis2;
-    for (int i = 0; i < 30; i++)
-      assert(basis2.basis[i].none());
-    for (int i = 0; i < n; i++) {
+    rep(i, 0, 30) assert(basis2.basis[i].none());
+    rep(i, 0, n) {
       int val;
       cin >> val;
       bitset<30> v = val;
@@ -51,7 +50,7 @@ int main() {
     cin >> m;
     basis basis3;
     xor_basis<30> basis4;
-    for (int j = 0; j < m; j++) {
+    rep(j, 0, m) {
       int val;
       cin >> val;
       bitset<30> v = val;

--- a/tests/library_checker_aizu_tests/mono_st_asserts.hpp
+++ b/tests/library_checker_aizu_tests/mono_st_asserts.hpp
@@ -3,21 +3,20 @@
 #include "../../library/monotonic_stack/cartesian_binary_tree.hpp"
 #include "../../library/monotonic_stack/cartesian_k_ary_tree.hpp"
 #include "../../library/data_structures_[l,r]/linear_rmq.hpp"
-tuple<int, vector<vector<int>>, vector<int>>
-min_cartesian_tree(const vector<int>& a,
-  const vector<int>& l, const vector<int>& r) {
+tuple<int, vector<vi>, vi> min_cartesian_tree(const vi& a,
+  const vi& l, const vi& r) {
   int n = sz(a);
   assert(sz(l) == n && sz(r) == n);
   auto is_node = [&](int i) -> bool {
     return r[i] == n || a[r[i]] < a[i];
   };
-  vector<int> to_min(n);
-  iota(begin(to_min), end(to_min), 0);
+  vi to_min(n);
+  iota(all(to_min), 0);
   for (int i = n - 1; i >= 0; i--)
     if (!is_node(i)) to_min[i] = to_min[r[i]];
-  vector<vector<int>> adj(n);
+  vector<vi> adj(n);
   int root = -1;
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     if (l[i] == -1 && r[i] == n) {
       assert(root == -1);
       root = i;
@@ -29,7 +28,7 @@ min_cartesian_tree(const vector<int>& a,
   }
   return {root, adj, to_min};
 }
-void mono_st_asserts(const vector<int>& a) {
+void mono_st_asserts(const vi& a) {
   vector<function<bool(int, int)>> compares;
   compares.push_back(less());
   compares.push_back(less_equal());
@@ -42,9 +41,8 @@ void mono_st_asserts(const vector<int>& a) {
     {
       vector old_way_ri = mono_st(vi{rbegin(a), rend(a)},
         [&](int x, int y) { return !cmp(y, x); });
-      reverse(begin(old_way_ri), end(old_way_ri));
-      transform(begin(old_way_ri), end(old_way_ri),
-        begin(old_way_ri),
+      ranges::reverse(old_way_ri);
+      ranges::transform(old_way_ri, begin(old_way_ri),
         [&](int i) { return sz(a) - i - 1; });
       assert(r == old_way_ri);
     }
@@ -70,20 +68,17 @@ void mono_st_asserts(const vector<int>& a) {
   // test cartesian tree against old method
   auto l = mono_st(a, less()), r = mono_range(l),
        p = cart_k_ary_tree(a, l);
-  assert(count(begin(p), end(p), -1) == !empty(a));
-  for (int i = 0; i < n; i++)
-    assert(-1 <= p[i] && p[i] < n && p[i] != i);
+  assert(ranges::count(p, -1) == !empty(a));
+  rep(i, 0, n) assert(-1 <= p[i] && p[i] < n && p[i] != i);
   auto [root, adj, to_min] = min_cartesian_tree(a, l, r);
-  vector<int> p_old_method(n, -2);
+  vi p_old_method(n, -2);
   auto set_val = [&](int i, int val) -> void {
     assert(p_old_method[i] == -2);
     p_old_method[i] = val;
   };
   assert((root == -1) == empty(a));
   if (root != -1) set_val(root, -1);
-  for (int i = 0; i < n; i++)
-    for (int j : adj[i]) set_val(j, i);
-  for (int i = 0; i < n; i++)
-    if (to_min[i] > i) set_val(i, to_min[i]);
+  rep(i, 0, n) for (int j : adj[i]) set_val(j, i);
+  rep(i, 0, n) if (to_min[i] > i) set_val(i, to_min[i]);
   assert(p == p_old_method);
 }

--- a/tests/library_checker_aizu_tests/monotonic_stack_related/cartesian_binary_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/monotonic_stack_related/cartesian_binary_tree.test.cpp
@@ -6,10 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   auto l = mono_st(a, less()), p = cart_binary_tree(l);
-  for (int i = 0; i < n; i++)
-    cout << (p[i] == -1 ? i : p[i]) << " ";
+  rep(i, 0, n) cout << (p[i] == -1 ? i : p[i]) << " ";
   return 0;
 }

--- a/tests/library_checker_aizu_tests/monotonic_stack_related/cartesian_k_ary_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/monotonic_stack_related/cartesian_k_ary_tree.test.cpp
@@ -7,22 +7,22 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   mono_st_asserts(a);
   auto l = mono_st(a, less()), r = mono_range(l),
        p = cart_k_ary_tree(a, l);
-  assert(*min_element(begin(p), end(p)) == -1);
-  assert(*max_element(begin(p), end(p)) < n);
-  vector<int> a_neg(n);
-  transform(begin(a), end(a), begin(a_neg),
+  assert(*ranges::min_element(p) == -1);
+  assert(*ranges::max_element(p) < n);
+  vi a_neg(n);
+  ranges::transform(a, begin(a_neg),
     [](int x) { return -x; });
   auto le_neg = mono_st(a_neg, greater()),
        ri_neg = mono_range(le_neg),
        p_neg = cart_k_ary_tree(a_neg, le_neg);
   assert(r == ri_neg);
   assert(p == p_neg);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     if (p[i] != -1)
       assert(a[p[i]] < a[i]); // because distinct numbers
     cout << (p[i] == -1 ? i : p[i]) << " ";

--- a/tests/library_checker_aizu_tests/monotonic_stack_related/count_rectangles.test.cpp
+++ b/tests/library_checker_aizu_tests/monotonic_stack_related/count_rectangles.test.cpp
@@ -10,29 +10,26 @@ int main() {
   int n, m;
   cin >> n >> m;
   vector<vector<bool>> grid(n, vector<bool>(m));
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < m; j++) {
+  rep(i, 0, n) {
+    rep(j, 0, m) {
       bool val;
       cin >> val;
       grid[i][j] = !val;
     }
   }
   {
-    vector<int> h(m);
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < m; j++)
-        h[j] = (!grid[i][j]) * (h[j] + 1);
+    vi h(m);
+    rep(i, 0, n) {
+      rep(j, 0, m) h[j] = (!grid[i][j]) * (h[j] + 1);
       mono_st_asserts(h);
     }
   }
-  vector<vector<int>> size_counts = count_rectangles(grid);
+  vector<vi> size_counts = count_rectangles(grid);
   {
-    vector<vector<int>> temp_grid(n, vector<int>(m));
-    for (int i = 0; i < n; i++)
-      for (int j = 0; j < m; j++)
-        temp_grid[i][j] = grid[i][j];
+    vector<vi> temp_grid(n, vi(m));
+    rep(i, 0, n) rep(j, 0, m) temp_grid[i][j] = grid[i][j];
     SubMatrix<int> sm(temp_grid);
-    vector<pair<int, int>> tests;
+    vector<pii> tests;
     {
       for (int i = 1; i <= min(5, n); i++)
         for (int j = 1; j <= min(5, m); j++)

--- a/tests/library_checker_aizu_tests/monotonic_stack_related/max_rect_histogram.test.cpp
+++ b/tests/library_checker_aizu_tests/monotonic_stack_related/max_rect_histogram.test.cpp
@@ -7,8 +7,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
   mono_st_asserts(a);
   cout << max_rect_histogram(a) << '\n';
   return 0;

--- a/tests/library_checker_aizu_tests/perm_tree_asserts.hpp
+++ b/tests/library_checker_aizu_tests/perm_tree_asserts.hpp
@@ -1,13 +1,13 @@
 #pragma once
 #include "../../library/data_structures_[l,r)/rmq.hpp"
 #include "../../library/data_structures_[l,r)/uncommon/permutation_tree.hpp"
-perm_tree perm_tree_asserts(const vector<int>& a) {
+perm_tree perm_tree_asserts(const vi& a) {
   int n = sz(a);
   perm_tree pt(a);
   {
-    vector<int> a_reverse(rbegin(a), rend(a));
+    vi a_reverse(rbegin(a), rend(a));
     perm_tree pt_reverse(a_reverse);
-    queue<pair<int, int>> q;
+    queue<pii> q;
     q.push({pt.root, pt_reverse.root});
     while (!empty(q)) {
       auto [u, u_reverse] = q.front();
@@ -21,11 +21,10 @@ perm_tree perm_tree_asserts(const vector<int>& a) {
       assert(pt.p[u].mn_idx ==
              n - (pt_reverse.p[u_reverse].mn_idx +
                    pt_reverse.p[u_reverse].len));
-      for (int i = 0; i < sz(pt.ch[u]); i++)
-        q.push({pt.ch[u][i],
-          pt_reverse
-            .ch[u_reverse]
-               [sz(pt_reverse.ch[u_reverse]) - i - 1]});
+      rep(i, 0, sz(pt.ch[u])) q.push({pt.ch[u][i],
+        pt_reverse
+          .ch[u_reverse]
+             [sz(pt_reverse.ch[u_reverse]) - i - 1]});
     }
   }
   RMQ rmq_min(a, [](int x, int y) { return min(x, y); });
@@ -36,7 +35,7 @@ perm_tree perm_tree_asserts(const vector<int>& a) {
          pt.p[root].mn_num == 0 && pt.p[root].len == n);
   if (n == 1) assert(sz(ch) == 1);
   else assert(n + 1 <= sz(ch) && sz(ch) < 2 * n);
-  for (int u = 0; u < sz(ch); u++) {
+  rep(u, 0, sz(ch)) {
     {
       int mn_num_rmq = rmq_min.query(pt.p[u].mn_idx,
         pt.p[u].mn_idx + pt.p[u].len);
@@ -71,20 +70,20 @@ perm_tree perm_tree_asserts(const vector<int>& a) {
           pt.p[u].mn_num + pt.p[u].len ==
             pt.p[ch[u].back()].mn_num +
               pt.p[ch[u].back()].len));
-      for (int i = 1; i < sz(ch[u]); i++) {
-        int prev = ch[u][i - 1], curr = ch[u][i];
-        assert(pt.p[prev].mn_idx + pt.p[prev].len ==
-               pt.p[curr].mn_idx);
-        assert(pt.p[u].is_join == pt.touches(prev, curr));
+      rep(i, 1, sz(ch[u])) {
+        int prv = ch[u][i - 1], cur = ch[u][i];
+        assert(pt.p[prv].mn_idx + pt.p[prv].len ==
+               pt.p[cur].mn_idx);
+        assert(pt.p[u].is_join == pt.touches(prv, cur));
       }
       if (sz(ch[u]) <= 10) {
-        for (int i = 0; i < sz(ch[u]); i++) {
+        rep(i, 0, sz(ch[u])) {
           int node_le = ch[u][i];
           int running_min = pt.p[node_le].mn_num;
           int running_max =
             pt.p[node_le].mn_num + pt.p[node_le].len;
           int running_sum = pt.p[node_le].len;
-          for (int j = i + 1; j < sz(ch[u]); j++) {
+          rep(j, i + 1, sz(ch[u])) {
             int node_ri = ch[u][j];
             running_min =
               min(running_min, pt.p[node_ri].mn_num);

--- a/tests/library_checker_aizu_tests/scc_asserts.hpp
+++ b/tests/library_checker_aizu_tests/scc_asserts.hpp
@@ -2,17 +2,17 @@
 #include "../../library/contest/random.hpp"
 #include "../../library/graphs/strongly_connected_components/add_edges_strongly_connected.hpp"
 #include "../../library/graphs/strongly_connected_components/offline_incremental_scc.hpp"
-void scc_asserts(const vector<vector<int>>& adj) {
+void scc_asserts(const vector<vi>& adj) {
   int n = sz(adj);
   auto [num_sccs, scc_id] = scc(adj);
   {
     // sanity check for reverse topo order of SCCs
-    for (int i = 0; i < n; i++)
-      for (auto j : adj[i]) assert(scc_id[i] >= scc_id[j]);
+    rep(i, 0, n) for (auto j : adj[i])
+      assert(scc_id[i] >= scc_id[j]);
   }
   vector<bool> is_zero_in(num_sccs, 1),
     is_zero_out(num_sccs, 1);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     for (int v : adj[i]) {
       if (scc_id[i] == scc_id[v]) continue;
       is_zero_in[scc_id[v]] = 0;
@@ -21,15 +21,12 @@ void scc_asserts(const vector<vector<int>>& adj) {
   }
   // since {num_sccs-1, ..., 2, 1, 0} is a topo order
   assert(is_zero_in[num_sccs - 1] && is_zero_out[0]);
-  int num_zero_in =
-    int(count(begin(is_zero_in), end(is_zero_in), 1));
-  int num_zero_out =
-    int(count(begin(is_zero_out), end(is_zero_out), 1));
-  vector<pair<int, int>> edges =
-    extra_edges(adj, num_sccs, scc_id);
+  int num_zero_in = int(ranges::count(is_zero_in, 1));
+  int num_zero_out = int(ranges::count(is_zero_out, 1));
+  vector<pii> edges = extra_edges(adj, num_sccs, scc_id);
   if (num_sccs == 1) assert(sz(edges) == 0);
   else assert(sz(edges) == max(num_zero_in, num_zero_out));
-  vector<vector<int>> adj_copy(adj);
+  vector<vi> adj_copy(adj);
   for (auto [u, v] : edges) {
     assert(u != v);
     adj_copy[u].push_back(v);

--- a/tests/library_checker_aizu_tests/strings/kmp.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/kmp.test.cpp
@@ -8,7 +8,6 @@ int main() {
   cin >> haystack >> needle;
   KMP kmp(vi(all(needle)));
   vector<bool> is_m = kmp.find_str(vi(all(haystack)));
-  for (int i = 0; i < sz(is_m); i++)
-    if (is_m[i]) cout << i << '\n';
+  rep(i, 0, sz(is_m)) if (is_m[i]) cout << i << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/strings/lcp_array.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcp_array.test.cpp
@@ -12,9 +12,9 @@ int main() {
     // to test commented example
     string s = "banana";
     auto [sa, sa_inv, lcp] = get_sa(s, 256);
-    assert(sa == vector<int>({5, 3, 1, 0, 4, 2}));
-    assert(sa_inv == vector<int>({3, 2, 5, 1, 4, 0}));
-    assert(lcp == vector<int>({1, 3, 0, 0, 2}));
+    assert(sa == vi({5, 3, 1, 0, 4, 2}));
+    assert(sa_inv == vi({3, 2, 5, 1, 4, 0}));
+    assert(lcp == vi({1, 3, 0, 0, 2}));
   }
   string s;
   cin >> s;
@@ -25,7 +25,6 @@ int main() {
   assert(sa_inv == sa_inv1);
   assert(lcp == lcp1);
   assert(sz(lcp) == n - 1);
-  cout << 1LL * n * (n + 1) / 2 -
-            accumulate(begin(lcp), end(lcp), 0LL)
+  cout << 1LL * n * (n + 1) / 2 - accumulate(all(lcp), 0LL)
        << '\n';
 }

--- a/tests/library_checker_aizu_tests/strings/lcp_query_palindrome.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcp_query_palindrome.test.cpp
@@ -10,11 +10,9 @@ int main() {
   s = s + '$' + string(rbegin(s), rend(s));
   auto [sa, sa_inv, lcp] = get_sa(vi(all(s)), 256);
   sa_query lq(vi(all(s)), sa, sa_inv, lcp);
-  for (int i = 0; i < n; i++)
-    for (int j = i; j < min(i + 2, n); j++)
-      cout << lq.len_lcp(j, (n - i - 1) + n + 1) * 2 -
-                (i == j)
-           << " ";
+  rep(i, 0, n) rep(j, i, min(i + 2, n)) cout
+    << lq.len_lcp(j, (n - i - 1) + n + 1) * 2 - (i == j)
+    << " ";
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/strings/lcp_query_zfunc.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcp_query_zfunc.test.cpp
@@ -42,8 +42,7 @@ int main() {
       else assert(sub1 > sub2);
     }
   }
-  for (int i = 0; i < sz(s); i++)
-    cout << lq.len_lcp(i, 0) << " ";
+  rep(i, 0, sz(s)) cout << lq.len_lcp(i, 0) << " ";
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/strings/lcs_dp.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcs_dp.test.cpp
@@ -13,7 +13,7 @@ int main() {
     rep(j, 0, 2) {
       lcs_dp lcs(vi(all(t)));
       for (char c : s) lcs.push_onto_s(c);
-      res[j] = int(count(begin(lcs.dp), end(lcs.dp), -1));
+      res[j] = int(ranges::count(lcs.dp, -1));
       swap(s, t);
     }
     assert(res[0] == res[1]);

--- a/tests/library_checker_aizu_tests/strings/lcs_dp.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcs_dp.test.cpp
@@ -6,11 +6,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int q;
   cin >> q;
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     string s, t;
     cin >> s >> t;
     array<int, 2> res;
-    for (int j = 0; j < 2; j++) {
+    rep(j, 0, 2) {
       lcs_dp lcs(vi(all(t)));
       for (char c : s) lcs.push_onto_s(c);
       res[j] = int(count(begin(lcs.dp), end(lcs.dp), -1));

--- a/tests/library_checker_aizu_tests/strings/lcs_queries.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcs_queries.test.cpp
@@ -8,13 +8,12 @@ int main() {
   string s, t;
   cin >> q >> s >> t;
   vector<array<int, 3>> queries(q);
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int a, b, c;
     cin >> a >> b >> c;
     queries[i] = {a, b, c};
   }
-  vector<int> res =
-    lcs_queries(vi(all(s)), vi(all(t)), queries);
+  vi res = lcs_queries(vi(all(s)), vi(all(t)), queries);
   for (int val : res) cout << val << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/strings/lcs_queries_merge_sort_tree.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/lcs_queries_merge_sort_tree.test.cpp
@@ -15,19 +15,19 @@ int main() {
     for (char c : s) {
       lcs.push_onto_s(c);
       {
-        vector<bool> seen(sz(t));
-        for (int i = 0; i < sz(t); i++) {
+        vector<bool> vis(sz(t));
+        rep(i, 0, sz(t)) {
           int val = lcs.dp[i];
           assert(val <= i);
           if (val == -1) continue;
-          assert(!seen[val]);
-          seen[val] = 1;
+          assert(!vis[val]);
+          vis[val] = 1;
         }
       }
       msts.emplace_back(lcs.dp);
     }
   }
-  for (int i = 0; i < q; i++) {
+  rep(i, 0, q) {
     int a, b, c;
     cin >> a >> b >> c;
     cout << msts[a].query(b, c, -1, b) << '\n';

--- a/tests/library_checker_aizu_tests/strings/manacher.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/manacher.test.cpp
@@ -9,13 +9,12 @@ int main() {
   cin >> s;
   int n = sz(s);
   pal_query pq(vi(all(s)));
-  vector<int> longest(longest_from_index(pq));
+  vi longest(longest_from_index(pq));
   {
-    vector<pair<int, int>> tests;
-    for (int i = 0; i < n; i++)
-      for (int j = i; j < min(n, i + 10); j++)
-        tests.emplace_back(i, j);
-    for (int i = 0; i < 30; i++) {
+    vector<pii> tests;
+    rep(i, 0, n) rep(j, i, min(n, i + 10))
+      tests.emplace_back(i, j);
+    rep(i, 0, 30) {
       int l = rnd(0, n - 1), r = rnd(0, n - 1);
       if (l > r) swap(l, r);
       tests.emplace_back(l, r);
@@ -27,7 +26,7 @@ int main() {
         (substr == string(rbegin(substr), rend(substr))));
     }
   }
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     assert(longest[i] < n);
     assert(pq.is_pal(i, longest[i]));
     if (longest[i] + 1 < n) {
@@ -38,7 +37,7 @@ int main() {
       }
     }
   }
-  for (int i = 0; i < sz(pq.man); i++) {
+  rep(i, 0, sz(pq.man)) {
     int r = i - pq.man[i];
     assert(r + 1 == pq.man[i] || pq.is_pal(pq.man[i], r));
     assert(pq.man[i] == 0 || r == n - 1 ||

--- a/tests/library_checker_aizu_tests/strings/multi_matching_bs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/multi_matching_bs.test.cpp
@@ -14,7 +14,7 @@ int main() {
   {
     auto [sa_le, sa_ri, s_l, s_r] =
       sf_a.find_str_fast(vi());
-    pair<int, int> short_res = sf_a.find_str(vi());
+    pii short_res = sf_a.find_str(vi());
     assert(sa_le == short_res.first &&
            sa_ri == short_res.second);
     assert(sa_le == 0 && sa_ri == sz(s));
@@ -27,7 +27,7 @@ int main() {
     cin >> t;
     auto [sa_le, sa_ri, s_l, s_r] =
       sf_a.find_str_fast(vi(all(t)));
-    pair<int, int> short_res = sf_a.find_str(vi(all(t)));
+    pii short_res = sf_a.find_str(vi(all(t)));
     assert(sa_le == short_res.first &&
            sa_ri == short_res.second);
     int str_len = s_r - s_l;

--- a/tests/library_checker_aizu_tests/strings/prefix_function.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/prefix_function.test.cpp
@@ -7,13 +7,12 @@ int main() {
   string s;
   cin >> s;
   int n = sz(s);
-  vector<int> pi = prefix_function(vi(all(s)));
+  vi pi = prefix_function(vi(all(s)));
   // prefix -> z func conversion
   // source:
   // https://codeforces.com/blog/entry/9612#comment-217621
-  vector<int> z(n, 0);
-  for (int i = 1; i < n; i++)
-    if (pi[i]) z[i - pi[i] + 1] = pi[i];
+  vi z(n, 0);
+  rep(i, 1, n) if (pi[i]) z[i - pi[i] + 1] = pi[i];
   for (int i = 1; i < n;) {
     int j, v;
     for (j = 1;
@@ -23,7 +22,7 @@ int main() {
     i += j;
   }
   z[0] = n;
-  for (int i = 0; i < n; i++) cout << z[i] << " ";
+  rep(i, 0, n) cout << z[i] << " ";
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/strings/sa_cmp.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/sa_cmp.test.cpp
@@ -6,15 +6,15 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> arr;
-  for (int i = 0; i < n; i++) {
+  vi arr;
+  rep(i, 0, n) {
     int val;
     cin >> val;
     arr.push_back(val);
   }
   int m;
   cin >> m;
-  for (int i = 0; i < m; i++) {
+  rep(i, 0, m) {
     int val;
     cin >> val;
     arr.push_back(val);

--- a/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
@@ -10,8 +10,7 @@ int main() {
   for (int& x : arr) cin >> x;
   vi compress(arr);
   ranges::sort(compress);
-  compress.erase(begin(ranges::unique(compress)),
-    end(compress));
+  compress.erase(unique(all(compress)), end(compress));
   for (int& x : arr) {
     int l = -1, r = int(sz(compress));
     while (r - l > 1) {

--- a/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
@@ -10,7 +10,8 @@ int main() {
   for (int& x : arr) cin >> x;
   vi compress(arr);
   ranges::sort(compress);
-  compress.erase(unique(all(compress)), end(compress));
+  compress.erase(begin(ranges::unique(compress)),
+    end(compress));
   for (int& x : arr) {
     int l = -1, r = int(sz(compress));
     while (r - l > 1) {

--- a/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/sa_sort_pairs.test.cpp
@@ -6,11 +6,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> arr(2 * n);
+  vi arr(2 * n);
   for (int& x : arr) cin >> x;
-  vector<int> compress(arr);
-  sort(begin(compress), end(compress));
-  compress.erase(unique(begin(compress), end(compress)),
+  vi compress(arr);
+  ranges::sort(compress);
+  compress.erase(begin(ranges::unique(compress)),
     end(compress));
   for (int& x : arr) {
     int l = -1, r = int(sz(compress));
@@ -24,9 +24,9 @@ int main() {
   }
   auto [sa, sa_inv, lcp] = get_sa(arr, int(sz(compress)));
   sa_query lq(arr, sa, sa_inv, lcp);
-  vector<int> idxs(n);
-  iota(begin(idxs), end(idxs), 0);
-  sort(begin(idxs), end(idxs), [&](int i, int j) -> bool {
+  vi idxs(n);
+  iota(all(idxs), 0);
+  ranges::sort(idxs, [&](int i, int j) -> bool {
     return lq.cmp_substrs(2 * i, 2 * (i + 1), 2 * j,
              2 * (j + 1)) < 0;
   });

--- a/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
@@ -16,14 +16,14 @@ int main() {
     auto [sa_le, sa_ri, s_l, s_r] =
       sf_a.find_str_fast(vi());
     assert(sa_le == 0 && sa_ri == sz(s));
-    pair<int, int> short_res = sf_a.find_str(vi());
+    pii short_res = sf_a.find_str(vi());
     assert(sa_le == short_res.first &&
            sa_ri == short_res.second);
     assert(s_r - s_l == 0);
   }
   auto [sa_le, sa_ri, s_l, s_r] =
     sf_a.find_str_fast(vi(all(t)));
-  pair<int, int> short_res = sf_a.find_str(vi(all(t)));
+  pii short_res = sf_a.find_str(vi(all(t)));
   assert(
     sa_le == short_res.first && sa_ri == short_res.second);
   int str_len = s_r - s_l;
@@ -32,9 +32,9 @@ int main() {
   assert(str_len == sz(t) || s_r == sz(s) ||
          t[str_len] != s[s_r]);
   assert((sa_le < sa_ri) == (str_len == sz(t)));
-  vector<int> matches(begin(sf_a.sa) + sa_le,
+  vi matches(begin(sf_a.sa) + sa_le,
     begin(sf_a.sa) + sa_ri);
-  sort(begin(matches), end(matches));
+  ranges::sort(matches);
   {
     // test find_substrs_concated
     string both = s + '$' + t;
@@ -49,32 +49,31 @@ int main() {
         {t_start + 1, t_start + 1},
         {t_start + 1, t_start + sz(t)}});
     for (int num_tests = 10; num_tests--;) {
-      vector<int> splits = {0, int(sz(t))};
+      vi splits = {0, int(sz(t))};
       for (int num_splits = rnd(0, 4); num_splits--;)
         splits.push_back(rnd(0, int(sz(t)) - 1));
-      sort(begin(splits), end(splits));
-      vector<pair<int, int>> subs;
-      for (int i = 1; i < sz(splits); i++)
-        subs.emplace_back(splits[i - 1] + t_start,
-          splits[i] + t_start);
+      ranges::sort(splits);
+      vector<pii> subs;
+      rep(i, 1, sz(splits)) subs.emplace_back(
+        splits[i - 1] + t_start, splits[i] + t_start);
       tests.push_back(subs);
     }
     for (const vector<pii>& subs : tests) {
       auto [sa_le2, sa_ri2, s_le2, s_ri2] =
         lq_both.find_substrs_concated(subs);
-      pair<int, int> short_res2 =
+      pii short_res2 =
         lq_both.find_substr(t_start, sz(both));
       assert(sa_le2 == short_res2.first &&
              sa_ri2 == short_res2.second);
       assert(both.substr(s_le2, s_ri2 - s_le2) == t);
       assert(sa_ri2 - sa_le2 == 1 + sa_ri - sa_le);
-      vector<int> matches_other(begin(lq_both.sa) + sa_le2,
+      vi matches_other(begin(lq_both.sa) + sa_le2,
         begin(lq_both.sa) + sa_ri2);
       matches_other.erase(
-        remove_if(begin(matches_other), end(matches_other),
-          [&](int val) { return val >= sz(s) + 1; }),
+        begin(ranges::remove_if(matches_other,
+          [&](int val) { return val >= sz(s) + 1; })),
         end(matches_other));
-      sort(begin(matches_other), end(matches_other));
+      ranges::sort(matches_other);
       assert(matches == matches_other);
     }
   }

--- a/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
@@ -70,8 +70,8 @@ int main() {
       vi matches_other(begin(lq_both.sa) + sa_le2,
         begin(lq_both.sa) + sa_ri2);
       matches_other.erase(
-        begin(ranges::remove_if(matches_other,
-          [&](int val) { return val >= sz(s) + 1; })),
+        remove_if(all(matches_other),
+          [&](int val) { return val >= sz(s) + 1; }),
         end(matches_other));
       ranges::sort(matches_other);
       assert(matches == matches_other);

--- a/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/single_matching_bs.test.cpp
@@ -70,8 +70,8 @@ int main() {
       vi matches_other(begin(lq_both.sa) + sa_le2,
         begin(lq_both.sa) + sa_ri2);
       matches_other.erase(
-        remove_if(all(matches_other),
-          [&](int val) { return val >= sz(s) + 1; }),
+        begin(ranges::remove_if(matches_other,
+          [&](int val) { return val >= sz(s) + 1; })),
         end(matches_other));
       ranges::sort(matches_other);
       assert(matches == matches_other);

--- a/tests/library_checker_aizu_tests/strings/suffix_array.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/suffix_array.test.cpp
@@ -28,7 +28,7 @@ int main() {
   {
     auto [sa_le, sa_ri, s_l, s_r] =
       sf_a.find_substrs_concated({{0, 0}});
-    pair<int, int> short_res = sf_a.find_substr(0, 0);
+    pii short_res = sf_a.find_substr(0, 0);
     assert(sa_le == short_res.first &&
            sa_ri == short_res.second);
     assert(sa_le == 0 && sa_ri == n);
@@ -37,14 +37,13 @@ int main() {
   {
     auto [sa_le, sa_ri, s_l, s_r] =
       sf_a.find_substrs_concated({{0, 0}, {n - 1, n - 1}});
-    pair<int, int> short_res =
-      sf_a.find_substr(n - 1, n - 1);
+    pii short_res = sf_a.find_substr(n - 1, n - 1);
     assert(sa_le == short_res.first &&
            sa_ri == short_res.second);
     assert(sa_le == 0 && sa_ri == n);
     assert(s_r - s_l == 0);
   }
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     assert(sa[sa_inv[i]] == i);
     assert(sa_inv[sa[i]] == i);
   }

--- a/tests/library_checker_aizu_tests/strings/trie.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/trie.test.cpp
@@ -7,7 +7,7 @@ int main() {
   int n;
   cin >> n;
   trie tr;
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     string type, s;
     cin >> type >> s;
     if (type == "insert") tr.insert(s);

--- a/tests/library_checker_aizu_tests/strings/wildcard_pattern_matching.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/wildcard_pattern_matching.test.cpp
@@ -15,10 +15,8 @@ ll modpow(ll a, ll e) {
 vl to_vec(const string& s) {
   int n = sz(s);
   vl res(n);
-  for (int i = 0; i < n; i++)
-    if (s[i] == '*') res[i] = 0;
-    else res[i] = s[i] - 'a' + 1;
-  return res;
+  rep(i, 0, n) if (s[i] == '*') res[i] = 0;
+  else res[i] = s[i] - 'a' + 1; return res;
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);

--- a/tests/library_checker_aizu_tests/strings/wildcard_pattern_matching.test.cpp
+++ b/tests/library_checker_aizu_tests/strings/wildcard_pattern_matching.test.cpp
@@ -15,8 +15,11 @@ ll modpow(ll a, ll e) {
 vl to_vec(const string& s) {
   int n = sz(s);
   vl res(n);
-  rep(i, 0, n) if (s[i] == '*') res[i] = 0;
-  else res[i] = s[i] - 'a' + 1; return res;
+  rep(i, 0, n) {
+    if (s[i] == '*') res[i] = 0;
+    else res[i] = s[i] - 'a' + 1;
+  }
+  return res;
 }
 int main() {
   cin.tie(0)->sync_with_stdio(0);

--- a/tests/library_checker_aizu_tests/trees/cd_count_paths_per_length.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/cd_count_paths_per_length.test.cpp
@@ -29,7 +29,7 @@ vector<ll> count_paths_per_length(vector<vi> adj) {
         swap(q, new_q);
       }
     }
-    sort(all(child_depths),
+    ranges::sort(child_depths,
       [&](auto& x, auto& y) { return sz(x) < sz(y); });
     vector total_depth(1, 1.0);
     for (const auto& cnt_depth : child_depths) {
@@ -46,8 +46,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
@@ -55,7 +55,7 @@ int main() {
   }
   cd_asserts(adj);
   vector<ll> cnt_len = count_paths_per_length(adj);
-  for (int i = 1; i < n; i++) cout << cnt_len[i] << " ";
+  rep(i, 1, n) cout << cnt_len[i] << " ";
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/trees/edge_cd_contour_range_query.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/edge_cd_contour_range_query.test.cpp
@@ -97,9 +97,9 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/edge_cd_contour_range_update.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/edge_cd_contour_range_update.test.cpp
@@ -96,9 +96,9 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/edge_cd_count_paths_per_length.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/edge_cd_count_paths_per_length.test.cpp
@@ -32,8 +32,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
@@ -44,7 +44,7 @@ int main() {
 #include "../edge_cd_asserts.hpp"
     edge_cd(adj, edge_cd_asserts);
   }
-  for (int i = 1; i < n; i++) cout << cnt_len[i] << " ";
+  rep(i, 1, n) cout << cnt_len[i] << " ";
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/trees/edge_cd_reroot_dp.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/edge_cd_reroot_dp.test.cpp
@@ -7,19 +7,19 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  vector<int> res(n);
-  for (int i = 0; i < n; i++) {
+  vi a(n);
+  vi res(n);
+  rep(i, 0, n) {
     cin >> a[i];
     res[i] = a[i];
   }
   vector<vi> adj(n);
-  vector<int> b(n - 1), c(n - 1);
-  vector<pair<int, int>> par(n, {-1, -1});
-  vector<vector<int>> base_adj(n);
+  vi b(n - 1), c(n - 1);
+  vector<pii> par(n, {-1, -1});
+  vector<vi> base_adj(n);
   {
-    vector<vector<pair<int, int>>> adj_with_id(n);
-    for (int i = 0; i < n - 1; i++) {
+    vector<vector<pii>> adj_with_id(n);
+    rep(i, 0, n - 1) {
       int u, v;
       cin >> u >> v >> b[i] >> c[i];
       adj[u].push_back(v);
@@ -76,24 +76,23 @@ int main() {
         self(self, v, u, curr_forw, curr_backw, side);
       }
     };
-    for (int i = 0; i < sz(adj[cent]); i++) {
+    rep(i, 0, sz(adj[cent])) {
       int e_id = edge_id(cent, adj[cent][i]);
       dfs(dfs, adj[cent][i], cent, {b[e_id], c[e_id]},
         {b[e_id], c[e_id]}, i < split);
     }
-    for (int side = 0; side < 2; side++)
-      for (auto [u, curr_b, curr_c] : all_backwards[side])
-        res[u] =
-          (res[u] + 1LL * curr_b * sum_forward[!side] +
-            1LL * curr_c * cnt_nodes[!side]) %
-          mod;
+    rep(side, 0, 2) for (auto [u, curr_b, curr_c] :
+      all_backwards[side]) res[u] =
+      (res[u] + 1LL * curr_b * sum_forward[!side] +
+        1LL * curr_c * cnt_nodes[!side]) %
+      mod;
   });
   swap(base_adj, adj);
   {
 #include "../edge_cd_asserts.hpp"
     edge_cd(adj, edge_cd_asserts);
   }
-  for (int i = 0; i < n; i++) cout << res[i] << ' ';
+  rep(i, 0, n) cout << res[i] << ' ';
   cout << '\n';
   return 0;
 }

--- a/tests/library_checker_aizu_tests/trees/hld_aizu1.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/hld_aizu1.test.cpp
@@ -7,11 +7,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n) {
     int k;
     cin >> k;
-    for (int j = 0; j < k; j++) {
+    rep(j, 0, k) {
       int v;
       cin >> v;
       assert(v != 0);

--- a/tests/library_checker_aizu_tests/trees/hld_aizu2.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/hld_aizu2.test.cpp
@@ -7,11 +7,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n) {
     int k;
     cin >> k;
-    for (int j = 0; j < k; j++) {
+    rep(j, 0, k) {
       int v;
       cin >> v;
       assert(v != 0);

--- a/tests/library_checker_aizu_tests/trees/hld_lib_checker_path.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/hld_lib_checker_path.test.cpp
@@ -7,10 +7,10 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);
@@ -18,7 +18,7 @@ int main() {
   }
   HLD<0> hld(adj);
   BIT bit(n);
-  for (int i = 0; i < n; i++) bit.update(hld.tin[i], a[i]);
+  rep(i, 0, n) bit.update(hld.tin[i], a[i]);
   while (q--) {
     int type;
     cin >> type;

--- a/tests/library_checker_aizu_tests/trees/hld_lib_checker_subtree_edges.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/hld_lib_checker_subtree_edges.test.cpp
@@ -8,9 +8,9 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
-  for (int i = 1; i < n; i++) {
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
+  rep(i, 1, n) {
     int par;
     cin >> par;
     adj[par].push_back(i);
@@ -18,7 +18,7 @@ int main() {
   }
   HLD<1> hld(adj);
   BIT bit(n);
-  for (int i = 0; i < n; i++) bit.update(hld.tin[i], a[i]);
+  rep(i, 0, n) bit.update(hld.tin[i], a[i]);
   while (q--) {
     int type;
     cin >> type;

--- a/tests/library_checker_aizu_tests/trees/hld_lib_checker_subtree_nodes.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/hld_lib_checker_subtree_nodes.test.cpp
@@ -8,9 +8,9 @@ int main() {
   int n, q;
   cin >> n >> q;
   vector<ll> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
-  for (int i = 1; i < n; i++) {
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
+  rep(i, 1, n) {
     int par;
     cin >> par;
     adj[par].push_back(i);
@@ -18,7 +18,7 @@ int main() {
   }
   HLD<0> hld(adj);
   BIT bit(n);
-  for (int i = 0; i < n; i++) bit.update(hld.tin[i], a[i]);
+  rep(i, 0, n) bit.update(hld.tin[i], a[i]);
   while (q--) {
     int type;
     cin >> type;

--- a/tests/library_checker_aizu_tests/trees/kth_path_hagerup.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/kth_path_hagerup.test.cpp
@@ -9,8 +9,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/kth_path_ladder.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/kth_path_ladder.test.cpp
@@ -6,8 +6,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/kth_path_linear.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/kth_path_linear.test.cpp
@@ -7,8 +7,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/kth_path_tree_lift.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/kth_path_tree_lift.test.cpp
@@ -8,8 +8,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n - 1) {
     int u, v;
     cin >> u >> v;
     adj[u].push_back(v);

--- a/tests/library_checker_aizu_tests/trees/lca_all_methods_aizu.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/lca_all_methods_aizu.test.cpp
@@ -9,8 +9,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 0; i < n; i++) {
+  vector<vi> adj(n);
+  rep(i, 0, n) {
     int k;
     cin >> k;
     adj[i].resize(k);
@@ -20,7 +20,7 @@ int main() {
   LCA lc(adj);
   linear_lca lin_lca(adj);
   compress_tree_asserts(adj, lc);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     assert(tl.lca(i, i) == i);
     assert(lc.lca(i, i) == i);
     assert(lin_lca.lca(i, i) == i);

--- a/tests/library_checker_aizu_tests/trees/lca_all_methods_lib_checker.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/lca_all_methods_lib_checker.test.cpp
@@ -8,8 +8,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n, q;
   cin >> n >> q;
-  vector<vector<int>> adj(n);
-  for (int i = 1; i < n; i++) {
+  vector<vi> adj(n);
+  rep(i, 1, n) {
     int par;
     cin >> par;
     adj[par].push_back(i);
@@ -18,7 +18,7 @@ int main() {
   LCA lc(adj);
   linear_lca lin_lca(adj);
   compress_tree_asserts(adj, lc);
-  for (int i = 0; i < n; i++) {
+  rep(i, 0, n) {
     assert(tl.lca(i, i) == i);
     assert(lc.lca(i, i) == i);
     assert(lc.in_subtree(i, i));

--- a/tests/library_checker_aizu_tests/trees/shallowest_aizu_tree_height.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/shallowest_aizu_tree_height.test.cpp
@@ -6,9 +6,9 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  map<pair<int, int>, int> weight;
-  for (int i = 0; i < n - 1; i++) {
+  vector<vi> adj(n);
+  map<pii, int> weight;
+  rep(i, 0, n - 1) {
     int u, v, w;
     cin >> u >> v >> w;
     weight[{u, v}] = w;
@@ -16,7 +16,7 @@ int main() {
     adj[u].push_back(v);
     adj[v].push_back(u);
   }
-  vector<int> res(n);
+  vi res(n);
   shallowest(adj, [&](int cent) {
     int lowest = 0;
     int curr_lowest = 0;
@@ -41,5 +41,5 @@ int main() {
       lowest = max(lowest, curr_lowest);
     }
   });
-  for (int i = 0; i < n; i++) cout << res[i] << '\n';
+  rep(i, 0, n) cout << res[i] << '\n';
 }

--- a/tests/library_checker_aizu_tests/trees/shallowest_lib_checker_tree_path_composite.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/shallowest_lib_checker_tree_path_composite.test.cpp
@@ -14,11 +14,11 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<int> a(n);
-  for (int i = 0; i < n; i++) cin >> a[i];
-  vector<vector<int>> adj(n);
+  vi a(n);
+  rep(i, 0, n) cin >> a[i];
+  vector<vi> adj(n);
   vector<vector<line>> weight(n);
-  for (int i = 0; i < n - 1; i++) {
+  rep(i, 0, n - 1) {
     int u, v, b, c;
     cin >> u >> v >> b >> c;
     adj[u].push_back(v);
@@ -26,9 +26,9 @@ int main() {
     weight[u].push_back({b, c});
     weight[v].push_back({b, c});
   }
-  vector<int> res(a);
+  vi res(a);
   shallowest(adj, [&](int cent) {
-    assert(ssize(adj[cent]) == ssize(weight[cent]));
+    assert(sz(adj[cent]) == sz(weight[cent]));
     int total_sum_evaluated = 0;
     int total_cnt_nodes = 0;
     int curr_sum_evaluated = 0;
@@ -56,7 +56,7 @@ int main() {
         (curr_sum_evaluated + 1LL * downwards[0] * a[v] +
           downwards[1]) %
         mod;
-      for (int i = 0; i < ssize(adj[v]); i++) {
+      rep(i, 0, sz(adj[v])) {
         int u = adj[v][i];
         line curr_line = weight[v][i];
         if (u != p)
@@ -64,7 +64,7 @@ int main() {
             compose(curr_line, upwards), forwards);
       }
     };
-    for (int i = 0; i < ssize(adj[cent]); i++) {
+    rep(i, 0, sz(adj[cent])) {
       curr_sum_evaluated = 0;
       curr_cnt_nodes = 0;
       dfs(dfs, adj[cent][i], cent, weight[cent][i],
@@ -75,7 +75,7 @@ int main() {
     }
     total_sum_evaluated = 0;
     total_cnt_nodes = 0;
-    for (int i = ssize(adj[cent]) - 1; i >= 0; i--) {
+    for (int i = sz(adj[cent]) - 1; i >= 0; i--) {
       curr_sum_evaluated = 0;
       curr_cnt_nodes = 0;
       dfs(dfs, adj[cent][i], cent, weight[cent][i],
@@ -85,7 +85,7 @@ int main() {
       total_cnt_nodes += curr_cnt_nodes;
     }
     for (int v : adj[cent]) {
-      for (int i = 0; i < ssize(adj[v]); i++) {
+      rep(i, 0, sz(adj[v])) {
         if (adj[v][i] == cent) {
           weight[v].erase(begin(weight[v]) + i);
           break;
@@ -93,6 +93,6 @@ int main() {
       }
     }
   });
-  for (int i = 0; i < n; i++) cout << res[i] << ' ';
+  rep(i, 0, n) cout << res[i] << ' ';
   cout << '\n';
 }

--- a/tests/library_checker_aizu_tests/trees/subtree_isomorphism.test.cpp
+++ b/tests/library_checker_aizu_tests/trees/subtree_isomorphism.test.cpp
@@ -8,8 +8,8 @@ int main() {
   cin.tie(0)->sync_with_stdio(0);
   int n;
   cin >> n;
-  vector<vector<int>> adj(n);
-  for (int i = 1; i < n; i++) {
+  vector<vi> adj(n);
+  rep(i, 1, n) {
     int p;
     cin >> p;
     adj[p].push_back(i);
@@ -17,7 +17,7 @@ int main() {
   }
   auto [num_distinct_subtrees, iso_id] = subtree_iso(adj);
   cout << num_distinct_subtrees << '\n';
-  for (int i = 0; i < n; i++) cout << iso_id[i] << " ";
+  rep(i, 0, n) cout << iso_id[i] << " ";
   cout << '\n';
   return 0;
 }


### PR DESCRIPTION
Standardizes `tests/library_checker_aizu_tests/` to the same conventions the library already follows: template macros, C++20 ranges/`<bit>`, and the naming conventions from #223. Test-only change — no library headers touched.

Tests already include `kactl_macros.hpp` (via `template.hpp`), so the macros were available everywhere but used inconsistently — e.g. 14 files used `rep(...)` while 108 used raw loops, and 84 files used `vector<int>` while 31 used `vi`, sometimes mixed within one file.

## Template macros (matching library style)

- `for (int i = a; i < b; i++)` -> `rep(i, a, b)` (~290 sites; loops with a second init variable, non-`<` conditions, or non-`++` increments left as raw `for`)
- `vector<int>` -> `vi` (175 sites), `pair<int, int>` -> `pii` (28)
- `long long` / `int64_t` -> `ll` (33 sites; `uint64_t` untouched)
- `ssize(x)` / `(int)size(x)` -> `sz(x)` (20)
- `begin(x), end(x)` -> `all(x)` (47)

## C++20 standardization (matching #221)

Use the `ranges::`/`views::`/`<bit>` form consistently wherever it applies:

- full-range `algo(all(x), ...)` -> `ranges::algo(x, ...)` for sort, reverse, fill, count, find, min/max_element, generate, transform, lower_bound, etc. (~70 sites across 29 files)
- membership checks use `ranges::find(x, v) == end(x)` / `ranges::count`; associative containers use `.contains()`
- `__lg` -> `<bit>` (`bit_width`/`bit_floor`) in `seg_tree_midpoint.test.cpp`
- left as-is: `iota`, `accumulate`, `partial_sum` (no C++20 ranges counterpart), genuinely offset/partial ranges
- left as-is: `unique`/`remove_if` stay in iterator form (`algo(all(x), ...)`) — the `ranges::` versions return a subrange needing a `begin(...)` unwrap and trip cppcheck `mismatchingContainerExpression` false positives (same rule as #221)

## Naming conventions (matching #223)

- `ans` -> `res` (range_parallel_dsu, count_paths)
- `curr` -> `cur`, `prev` -> `prv` (5 files)
- `seen`/`used` -> `vis` (3 files)
- `priority` -> `pri` (pq_ds_undo_sliding_window)
- `next` -> `nxt` (functional_graph, directed_cycle)

## Verification

- `clang-format --dry-run --Werror` (dev config) passes on all touched files
- all changed test files compile with `g++ -std=c++20 -O2 -Wall -Wextra`
- repo grep checks pass: no `endl`, no member-call `.size()`/`.begin()` forms, no `long long`/`vector<int>` stragglers, no `__lg`
- cppcheck suppression list audited: all line-pinned test-file entries still point at the same statements (the suppressed lines did not shift); several entries reference files that no longer exist, which predates this PR

