### PR TITLE
STL-leverage audit: midpoint in seg trees, emplace+exchange in num_distinct_subsequences

### DIFF
--- a/library/data_structures_[l,r)/seg_tree_uncommon/implicit.hpp
+++ b/library/data_structures_[l,r)/seg_tree_uncommon/implicit.hpp
@@ -42,7 +42,7 @@ template<int N> struct implicit_seg_tree {
     int v) {
     if (r <= tl || tr <= l) return;
     if (l <= tl && tr <= r) return apply(add, v);
-    int tm = tl + (tr - tl) / 2;
+    int tm = midpoint(tl, tr);
     push(tl, tm, tr, v);
     update(l, r, add, tl, tm, tree[v].lch);
     update(l, r, add, tm, tr, tree[v].rch);
@@ -55,7 +55,7 @@ template<int N> struct implicit_seg_tree {
   dt query(int l, int r, int tl, int tr, int v) {
     if (r <= tl || tr <= l) return unit;
     if (l <= tl && tr <= r) return tree[v].num;
-    int tm = tl + (tr - tl) / 2;
+    int tm = midpoint(tl, tr);
     push(tl, tm, tr, v);
     return op(query(l, r, tl, tm, tree[v].lch),
       query(l, r, tm, tr, tree[v].rch));

--- a/library/data_structures_[l,r)/seg_tree_uncommon/kth_smallest_query.hpp
+++ b/library/data_structures_[l,r)/seg_tree_uncommon/kth_smallest_query.hpp
@@ -25,7 +25,7 @@ struct kth_smallest {
   }
   int query(int k, int tl, int tr, int vl, int vr) {
     if (tr - tl == 1) return tl;
-    int tm = tl + (tr - tl) / 2;
+    int tm = midpoint(tl, tr);
     int cnt_l = pst.tree[pst.tree[vr].lch].sum -
                 pst.tree[pst.tree[vl].lch].sum;
     if (cnt_l >= k)

--- a/library/data_structures_[l,r)/seg_tree_uncommon/persistent.hpp
+++ b/library/data_structures_[l,r)/seg_tree_uncommon/persistent.hpp
@@ -30,7 +30,7 @@ struct PST {
       tree.emplace_back(tree[v].sum + change, 0, 0);
       return sz(tree) - 1;
     }
-    int tm = tl + (tr - tl) / 2;
+    int tm = midpoint(tl, tr);
     int lch = tree[v].lch;
     int rch = tree[v].rch;
     if (idx < tm) lch = update(idx, change, tl, tm, lch);
@@ -45,7 +45,7 @@ struct PST {
   ll query(int l, int r, int tl, int tr, int v) {
     if (v == 0 || r <= tl || tr <= l) return 0;
     if (l <= tl && tr <= r) return tree[v].sum;
-    int tm = tl + (tr - tl) / 2;
+    int tm = midpoint(tl, tr);
     return query(l, r, tl, tm, tree[v].lch) +
            query(l, r, tm, tr, tree[v].rch);
   }

--- a/library/math/num_distinct_subsequences.hpp
+++ b/library/math/num_distinct_subsequences.hpp
@@ -9,12 +9,11 @@ int num_subsequences(const vi& a, int mod) {
   rep(i, 0, sz(a)) {
     int& cur = dp[i + 1] = 2 * dp[i];
     if (cur >= mod) cur -= mod;
-    auto it = last.find(a[i]);
-    if (it != end(last)) {
-      cur -= dp[it->second];
+    auto [it, ins] = last.emplace(a[i], i);
+    if (!ins) {
+      cur -= dp[exchange(it->second, i)];
       if (cur < 0) cur += mod;
-      it->second = i;
-    } else last[a[i]] = i;
+    }
   }
   return dp.back();
 }


### PR DESCRIPTION
Result of a file-by-file vet of all 144 library headers for missed STL leverage (C++11 through C++23). Stacked on #229 — merge after it.

## Changes (4 files, 6 sites)

### `midpoint(tl, tr)` in the recursive seg trees (5 sites)

`implicit.hpp` (×2), `persistent.hpp` (×2), `kth_smallest_query.hpp` (×1):

```cpp
int tm = tl + (tr - tl) / 2;  // before
int tm = midpoint(tl, tr);    // after
```

Shorter, states intent, and matches the existing use in `offline_incremental_scc.hpp`. Identical value for `tl < tr` (`std::midpoint` rounds toward the first argument). The `lazy_seg_tree` family is untouched — it deliberately uses `split()` (power-of-two layout midpoint from the broken-profile blog), which is a different function.

### `num_distinct_subsequences.hpp`: `emplace` + `exchange` (1 line shorter, one fewer map lookup)

```cpp
// before: find, then branch into update-or-insert (double lookup on miss)
auto it = last.find(a[i]);
if (it != end(last)) {
  cur -= dp[it->second];
  if (cur < 0) cur += mod;
  it->second = i;
} else last[a[i]] = i;
// after: single lookup; exchange reads the old index and writes the new one
auto [it, ins] = last.emplace(a[i], i);
if (!ins) {
  cur -= dp[exchange(it->second, i)];
  if (cur < 0) cur += mod;
}
```

Verified equivalent against the old version and a brute-force distinct-subsequence counter over 3000 randomized cases under ASan/UBSan.

## Audit process

Four parallel scans over `data_structures_*`, `math`+`convolution`+`loops`+`contest`, `trees`+`graphs`+`dsu`+`flow`, and `strings`+`monotonic_stack`, followed by a pattern sweep for: midpoint/clamp/exchange/minmax candidates, `find != end` → `ranges::contains`, hand-rolled iota/binary-search/min-max loops, sort+unique+erase, map double lookups, `__builtin` leftovers, adjacent-element loops (`views::adjacent`/`zip` candidates), and C++23 additions (`fold_left`, `ranges::to`, `views::enumerate`).

## Evaluated and rejected (so the next audit doesn't re-litigate)

- **`clamp` in `hagerup_kth_par.hpp:36`** — `min(max(s, 2*K), d[l]+1)` is NOT `clamp(s, 2*K, d[l]+1)`: for shallow subtrees `d[l]+1 < 2*K` and `clamp` with `lo > hi` is UB (asserts under `_GLIBCXX_DEBUG`). The min/max form is load-bearing.
- **`views::enumerate`** — `rep(i, 0, sz(a))` is 17 chars; `for (auto [i, x] : views::enumerate(a))` is 40. Never shorter at ColumnLimit 59; rejected as a class.
- **`views::zip_transform` + `ranges::max` for `max_rect_histogram`** — saves one line but is UB on empty input where the loop returns 0, and reads worse.
- **`ranges::fold_left`** — zero `accumulate` calls exist to convert.
- **`ranges::contains`** — zero `find(...) != end(...)` patterns exist.
- **`exchange` for `back()`+`pop_back()` pairs** (euler_path, complement_graph_ccs) — no STL pop-and-return; no improvement.
- Everything else already landed in the earlier C++20/ranges/`<bit>` passes: `iota`, `partial_sum`, `minmax`, `mismatch`, `partition_point`, `ranges::sort` with projections, iterator form for subrange-returning algorithms.

## Validation

- All 5 covering tests (`kth_smallest_pst`, `persistent_seg_tree`, `persistent_queue_tree`, `implicit_seg_tree`, `num_subsequences`) compile clean with `g++ -std=c++23 -O2 -Wall -Wextra` and clang
- `clang-format --dry-run --Werror` passes on all changed files
- Randomized equivalence test for the num_subsequences rewrite (above)
