### PR TITLE
ci: bump deprecated actions; replace archived release action

### DIFF
--- a/.github/workflows/programming_team_code_ci.yml
+++ b/.github/workflows/programming_team_code_ci.yml
@@ -9,9 +9,9 @@ jobs:
   library_checker_aizu:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
     - name: Make preinstalled g++-14 the default g++
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
@@ -102,13 +102,12 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: ptc
-        path: tests/ptc.pdf
-    - uses: marvinpinto/action-automatic-releases@latest
+        path: tests/
+    - uses: softprops/action-gh-release@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        automatic_release_tag: ptc
+        tag_name: ptc
+        name: ptc
         prerelease: false
-        title: ptc
         files: tests/ptc.pdf
 
   update_main:


### PR DESCRIPTION
Replaces deprecated/unmaintained GitHub Actions:

- `actions/checkout@v1` → `@v4` and `actions/setup-python@v1` → `@v5` in `library_checker_aizu` (v1 targets Node versions that runners are deprecating; the rest of the workflow already uses v4)
- `marvinpinto/action-automatic-releases@latest` → `softprops/action-gh-release@v2` in `publish_pdf` (marvinpinto's action is archived and unmaintained; pinned `@latest` is also a supply-chain risk)

Details on the release step:

- `softprops/action-gh-release@v2` uses the default `GITHUB_TOKEN`; the workflow already grants `permissions: contents: write`
- `tag_name: ptc` / `name: ptc` reproduces the existing rolling-release behavior (updates the same `ptc` release/tag in place)
- `download-artifact` path changed from `tests/ptc.pdf` to `tests/`: with download-artifact@v4, `path` is the destination *directory*, so the old value produced `tests/ptc.pdf/ptc.pdf`; now `tests/ptc.pdf` is the file itself

Release behavior should be verified on the first dev push after merge (release `ptc` gets a fresh `ptc.pdf` asset).
