### PR TITLE
count_paths: define vl locally instead of relying on kactl NTT typedef

### DIFF
--- a/library/math/count_paths/count_paths_rectangle.hpp
+++ b/library/math/count_paths/count_paths_rectangle.hpp
@@ -7,6 +7,7 @@
 //! @endcode
 //! @time O((n + m)log(n + m))
 //! @space O(n + m)
+using vl = vector<ll>;
 array<vl, 2> get_right_and_top(vl left, vl bottom) {
   array<vl, 2> res;
   for (vl& cur : res) {


### PR DESCRIPTION
`count_paths_rectangle.hpp` and `count_paths_triangle.hpp` use the `vl` type alias without defining it — it silently leaks from kactl's `NumberTheoreticTransform.h` (`typedef vector<ll> vl;`). If kactl ever renames or drops that typedef, these headers stop compiling.

Fix: declare `using vl = vector<ll>;` in `count_paths_rectangle.hpp` (triangle includes rectangle, so one definition covers both). This matches the existing pattern in `wildcard_pattern_matching.hpp`.

Notes:
- The alias legally coexists with kactl's identical `typedef` — verified that redeclaration compiles clean with `-Wall -Wextra`
- Both count_paths tests compile; clang-format passes
- Deliberately *not* promoting `vl` into `kactl_macros.hpp`/`template.cpp`: that would diverge from upstream KACTL's template (which defines only `vi`/`pii`/`ll`), i.e. change what the team hand-types at contest. The remaining ~20 `vector<ll>` spell-outs are consistent with KACTL convention and left as-is.
