### PR TITLE
docs: state unwritten contracts in doc comments

### DIFF
--- a/library/graphs/dijkstra.hpp
+++ b/library/graphs/dijkstra.hpp
@@ -4,6 +4,7 @@
 //!   auto d = dijkstra(g, source);
 //! @endcode
 //! d[v] = min dist from source->..->v
+//! requires weights >= 0
 //! @time O(n + (m log m))
 //! @space O(n + m)
 vector<ll> dijkstra(const auto& g, int s) {

--- a/library/graphs/uncommon/enumerate_triangles.hpp
+++ b/library/graphs/uncommon/enumerate_triangles.hpp
@@ -5,6 +5,7 @@
 //!       //u, v, w form a triangle
 //!   });
 //! @endcode
+//! requires no self loops or multi edges
 //! @time O(n + m ^ (3/2))
 //! @space O(n + m)
 void enumerate_triangles(const vector<pii>& edges, int n,

--- a/library/loops/submasks.hpp
+++ b/library/loops/submasks.hpp
@@ -1,5 +1,6 @@
 #pragma once
 //! loops over submasks in decreasing order
+//! excludes the empty submask
 //! @param mask a submask of 2^n-1
 //! @time O(3^n) to iterate every submask
 //!   of every mask of size n

--- a/library/math/derangements.hpp
+++ b/library/math/derangements.hpp
@@ -4,6 +4,7 @@
 //!   auto der = derangements(n, mod);
 //! @endcode
 //! der[i] = number of permutations p with p[i]!=i
+//! requires n >= 1
 //! @time O(n)
 //! @space O(n)
 vector<ll> derangements(int n, int mod) {

--- a/library/math/matrix_related/matrix_mult.hpp
+++ b/library/math/matrix_related/matrix_mult.hpp
@@ -1,5 +1,6 @@
 #pragma once
 //! https://codeforces.com/blog/entry/80195
+//! watch for overflow if T is an integer type
 //! @time O(n * m * inner)
 //! @space O(n * m)
 template<class T>

--- a/library/math/matrix_related/row_reduce.hpp
+++ b/library/math/matrix_related/row_reduce.hpp
@@ -6,6 +6,7 @@
 //! columns [0,cols) of mat represent a matrix
 //! columns [cols,m) of mat are also
 //!   affected by row operations
+//! requires mod is prime
 //! @time O(n * m * min(cols, n))
 //! @space O(1)
 pii row_reduce(vector<vi>& mat, int cols) {

--- a/library/math/mod_division.hpp
+++ b/library/math/mod_division.hpp
@@ -3,6 +3,7 @@
 //! @code
 //!   int quotient = mod_div(x, y); // returns x * y^-1
 //! @endcode
+//! requires gcd(y, mod) == 1
 //! @time O(log(y))
 //! @space O(1)
 const int mod = 998244353;

--- a/library/strings/binary_trie.hpp
+++ b/library/strings/binary_trie.hpp
@@ -4,6 +4,8 @@
 //!   bt.update(num, 1); // insert
 //!   bt.update(num, -1); // erase
 //! @endcode
+//! requires 0 <= num < 2^61
+//! walk requires a non-empty trie
 //! @time O(q * mx_bit)
 //! @space O(q * mx_bit)
 const ll mx_bit = 1LL << 60;

--- a/library/strings/kmp.hpp
+++ b/library/strings/kmp.hpp
@@ -9,6 +9,7 @@
 //!   auto match2 = kmp1.find_str(s_vec);
 //! @endcode
 //! if match[i] == 1 then s[i,ssize(t)) == t
+//! requires t non-empty
 //! @time O(|s| + |t|)
 //! @space O(|s| + |t|)
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/library/trees/centroid_decomp.hpp
+++ b/library/trees/centroid_decomp.hpp
@@ -4,6 +4,7 @@
 //!   vector<basic_string<int>> g(n);
 //!   vector<int> p = cd(g, [&](int c) {});
 //! @endcode
+//! g is mutated (edges removed)
 //! @time O(n log n)
 //! @space O(n)
 vi cd(auto& g, auto f) {

--- a/library/trees/edge_cd.hpp
+++ b/library/trees/edge_cd.hpp
@@ -11,6 +11,7 @@
 //!   });
 //! @endcode
 //! handle single-edge-paths separately
+//! g is mutated (edges reordered/removed)
 //! @time O(n logφ n)
 //! @space O(n)
 template<class G> void edge_cd(vector<G>& g, auto f) {

--- a/library/trees/hld.hpp
+++ b/library/trees/hld.hpp
@@ -7,6 +7,7 @@
 //!   });
 //!   auto [l, r] = hld.subtree(u); // [l, r)
 //! @endcode
+//! g is mutated (parent edges removed)
 //! @time O(n + q log^2 n)
 //! @space O(n)
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/tests/.config/.cppcheck_suppression_list
+++ b/tests/.config/.cppcheck_suppression_list
@@ -14,7 +14,7 @@ arrayIndexOutOfBoundsCond:library_checker_aizu_tests/math/linear_prime_sieve.tes
 negativeContainerIndex:../library/strings/suffix_array/burrows_wheeler.hpp:50
 useStlAlgorithm:../kactl/content/numerical/FastFourierTransform.h:53
 useStlAlgorithm:../library/graphs/strongly_connected_components/add_edges_strongly_connected.hpp:58
-useStlAlgorithm:../library/math/matrix_related/row_reduce.hpp:28
+useStlAlgorithm:../library/math/matrix_related/row_reduce.hpp:29
 useStlAlgorithm:../library/math/count_paths/count_paths_triangle.hpp:25
 useStlAlgorithm:../library/math/matrix_related/xor_basis_unordered.hpp:14
 shadowFunction:../kactl/content/graph/BinaryLifting.h:17
@@ -35,7 +35,7 @@ syntaxError:../library/math/prime_sieve/calc_sieve.hpp:6
 syntaxError:../library/math/prime_sieve/calc_linear_sieve.hpp:6
 syntaxError:../library/loops/chooses.hpp:7
 syntaxError:../library/loops/quotients.hpp:10
-syntaxError:../library/loops/submasks.hpp:7
+syntaxError:../library/loops/submasks.hpp:8
 syntaxError:../library/loops/supermasks.hpp:8
 syntaxError:../library/math/prime_sieve/mobius.hpp:6
 syntaxError:../library/trees/lca_rmq/iterate_subtree.hpp:6


### PR DESCRIPTION
Documents unwritten contracts — preconditions the code relies on but the `//!` doc comments didn't state. Comment-only change (0 code lines touched), plus two line-pin bumps in the cppcheck suppression list.

Each contract was verified against the exact line that breaks if it's violated:

| File | Contract added | What happens if violated |
|---|---|---|
| `graphs/dijkstra.hpp` | `requires weights >= 0` | silently wrong distances |
| `strings/binary_trie.hpp` | `requires 0 <= num < 2^61`; `walk requires a non-empty trie` | wrong result (bits above 60 ignored; walk on empty trie follows -1) |
| `math/mod_division.hpp` | `requires gcd(y, mod) == 1` | assert fires |
| `math/matrix_related/row_reduce.hpp` | `requires mod is prime` | mod_div asserts / wrong answer (needs every nonzero pivot invertible) |
| `math/matrix_related/matrix_mult.hpp` | `watch for overflow if T is an integer type` | silent overflow (fine with modint, as in tests) |
| `graphs/uncommon/enumerate_triangles.hpp` | `requires no self loops or multi edges` | self-loop u==v makes `tie` comparison degenerate; multi-edges double-count |
| `loops/submasks.hpp` | `excludes the empty submask` | loop condition `submask;` stops before 0 — easy 4am surprise |
| `math/derangements.hpp` | `requires n >= 1` | `dp[0] = 1` on empty vector is UB |
| `strings/kmp.hpp` | `requires t non-empty` | `pi[j - 1]` with j==sz(t)==0 reads pi[-1] |
| `trees/hld.hpp` | `g is mutated (parent edges removed)` | caller reuses g afterward and gets a broken graph |
| `trees/centroid_decomp.hpp` | `g is mutated (edges removed)` | same |
| `trees/edge_cd.hpp` | `g is mutated (edges reordered/removed)` | same |

Findings that were considered and deliberately NOT documented (checked against the code):
- "trees must be rooted at 0 / connected" — universal convention across every tree structure in the repo; documenting it on 7 files individually adds noise, and `vector<basic_string<int>> g(n)` usage blocks already imply the shape
- "n >= 1" on DSU/SCC/rmq etc. — constructors are safe on n=0 (empty vectors, loops don't run); only ops on nonexistent indices break, which is true of every container
- rmq `assert(l < r)` — enforced by an assert already in the code, self-documenting
- suffix_array `0 <= s[i] < max_num` — already documented in that header
- hungarian `1 <= n <= m` — already documented (`1<=i<=n<=m`)
- several sub-agent claims were simply wrong (e.g. "partitions breaks on n=0" — `vector dp(0)` + non-executing loop is fine; "xor_convolution power-of-2 undocumented" — it's in the @code block)

Validation:
- diff outside the suppression list is 100% comment lines
- clang-format `--dry-run --Werror` passes on all changed files
- `grep_clangformat_cppcheck.sh` passes
- affected tests compile: dijkstra, derangement, matrix_mult, matrix_determinant (row_reduce+mod_division), kmp, binary_trie
