### PR TITLE
docs: fix wrong examples and time/space claims

### DIFF
--- a/library/convolution/min_plus_convolution_convex_and_arbitrary.hpp
+++ b/library/convolution/min_plus_convolution_convex_and_arbitrary.hpp
@@ -2,7 +2,7 @@
 //! @param convex,arbitrary arrays where convex satisfies
 //!   convex[i+1]-convex[i] <= convex[i+2]-convex[i+1]
 //! @returns array `res` where `res[k]` = the min of
-//!   (a[i]+b[j]) for all pairs (i,j) where i+j==k
+//!   (convex[j]+arbitrary[i]) over pairs with i+j==k
 //! @time O((n + m) log (n + m))
 //! @space O(n + m)
 vi min_plus(const vi& convex, const vi& arbitrary) {

--- a/library/data_structures_[l,r)/bit.hpp
+++ b/library/data_structures_[l,r)/bit.hpp
@@ -5,8 +5,8 @@
 //!     // sum = a[0] + a[1] + ... + a[r - 1]
 //!   });
 //!   int r = bit.walk2(sum);
-//!   // Returns min r s.t. sum of [0,r] >= sum
-//!   // Returns n if sum of [0,n-1] < sum
+//!   // Returns min r s.t. sum of [0,r+1) >= sum
+//!   // Returns n if sum of [0,n) < sum
 //!   // Returns -1 if sum <= 0
 //! @endcode
 //! @time O(n + q log n)

--- a/library/graphs/dijkstra.hpp
+++ b/library/graphs/dijkstra.hpp
@@ -4,6 +4,7 @@
 //!   auto d = dijkstra(g, source);
 //! @endcode
 //! d[v] = min dist from source->..->v
+//! requires weights >= 0
 //! @time O(n + (m log m))
 //! @space O(n + m)
 vector<ll> dijkstra(const auto& g, int s) {

--- a/library/graphs/min_vertex_cover.hpp
+++ b/library/graphs/min_vertex_cover.hpp
@@ -9,8 +9,8 @@
 //!   auto [mvc_l, mvc_r] = cover(g, r);
 //!   // mvc_l[u] == 1 iff u in mvc
 //! @endcode
-//! @time O(n + q * log n)
-//! @space O(n * \alpha(n))
+//! @time O(n + m)
+//! @space O(n)
 pair<vi, vi> cover(const vector<vi>& g, vi& r) {
   int n = sz(g), t = 0;
   vi cl(n), cr(sz(r)), q(n);

--- a/library/graphs/uncommon/enumerate_triangles.hpp
+++ b/library/graphs/uncommon/enumerate_triangles.hpp
@@ -5,6 +5,7 @@
 //!       //u, v, w form a triangle
 //!   });
 //! @endcode
+//! requires no self loops or multi edges
 //! @time O(n + m ^ (3/2))
 //! @space O(n + m)
 void enumerate_triangles(const vector<pii>& edges, int n,

--- a/library/loops/submasks.hpp
+++ b/library/loops/submasks.hpp
@@ -1,5 +1,6 @@
 #pragma once
 //! loops over submasks in decreasing order
+//! excludes the empty submask
 //! @param mask a submask of 2^n-1
 //! @time O(3^n) to iterate every submask
 //!   of every mask of size n

--- a/library/math/derangements.hpp
+++ b/library/math/derangements.hpp
@@ -4,6 +4,7 @@
 //!   auto der = derangements(n, mod);
 //! @endcode
 //! der[i] = number of permutations p with p[i]!=i
+//! requires n >= 1
 //! @time O(n)
 //! @space O(n)
 vector<ll> derangements(int n, int mod) {

--- a/library/math/matrix_related/matrix_mult.hpp
+++ b/library/math/matrix_related/matrix_mult.hpp
@@ -1,5 +1,6 @@
 #pragma once
 //! https://codeforces.com/blog/entry/80195
+//! watch for overflow if T is an integer type
 //! @time O(n * m * inner)
 //! @space O(n * m)
 template<class T>

--- a/library/math/matrix_related/matrix_mult.hpp
+++ b/library/math/matrix_related/matrix_mult.hpp
@@ -1,6 +1,5 @@
 #pragma once
 //! https://codeforces.com/blog/entry/80195
-//! watch for overflow if T is an integer type
 //! @time O(n * m * inner)
 //! @space O(n * m)
 template<class T>

--- a/library/math/matrix_related/row_reduce.hpp
+++ b/library/math/matrix_related/row_reduce.hpp
@@ -6,6 +6,7 @@
 //! columns [0,cols) of mat represent a matrix
 //! columns [cols,m) of mat are also
 //!   affected by row operations
+//! requires mod is prime
 //! @time O(n * m * min(cols, n))
 //! @space O(1)
 pii row_reduce(vector<vi>& mat, int cols) {

--- a/library/math/mod_division.hpp
+++ b/library/math/mod_division.hpp
@@ -3,6 +3,7 @@
 //! @code
 //!   int quotient = mod_div(x, y); // returns x * y^-1
 //! @endcode
+//! requires gcd(y, mod) == 1
 //! @time O(log(y))
 //! @space O(1)
 const int mod = 998244353;

--- a/library/math/num_distinct_subsequences.hpp
+++ b/library/math/num_distinct_subsequences.hpp
@@ -1,6 +1,6 @@
 #pragma once
 //! returns the number of distinct subsequences
-//!   of a, including the empty subsquence
+//!   of a, including the empty subsequence
 //! @time O(n log n)
 //! @space O(n)
 int num_subsequences(const vi& a, int mod) {

--- a/library/math/partitions.hpp
+++ b/library/math/partitions.hpp
@@ -4,7 +4,7 @@ const int mod = 998'244'353;
 //! @code
 //!   auto p = partitions(n);
 //! @endcode
-//! p[i] = number of partitions of i numbers
+//! p[i] = number of partitions of i
 //! @time O(n sqrt n)
 //! @space O(n)
 vector<ll> partitions(int n) {

--- a/library/strings/binary_trie.hpp
+++ b/library/strings/binary_trie.hpp
@@ -4,6 +4,8 @@
 //!   bt.update(num, 1); // insert
 //!   bt.update(num, -1); // erase
 //! @endcode
+//! requires 0 <= num < 2^61
+//! walk requires a non-empty trie
 //! @time O(q * mx_bit)
 //! @space O(q * mx_bit)
 const ll mx_bit = 1LL << 60;

--- a/library/strings/kmp.hpp
+++ b/library/strings/kmp.hpp
@@ -9,6 +9,7 @@
 //!   auto match2 = kmp1.find_str(s_vec);
 //! @endcode
 //! if match[i] == 1 then s[i,ssize(t)) == t
+//! requires t non-empty
 //! @time O(|s| + |t|)
 //! @space O(|s| + |t|)
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/library/strings/suffix_array/compare/compare_substrings.hpp
+++ b/library/strings/suffix_array/compare/compare_substrings.hpp
@@ -7,9 +7,9 @@
 //!   int cmp = saq.cmp_substrs(l1,r1,l2,r2);
 //! @endcode
 //! requires l1,l2 < n
-//! if cmp1<0 then s[l1,r1) < s[l2,r2)
-//! if cmp1=0 then s[l1,r1) = s[l2,r2)
-//! if cmp1>0 then s[l1,r1) > s[l2,r2)
+//! if cmp<0 then s[l1,r1) < s[l2,r2)
+//! if cmp=0 then s[l1,r1) = s[l2,r2)
+//! if cmp>0 then s[l1,r1) > s[l2,r2)
 //! @time O(1)
 //! @space O(1)
 int cmp_substrs(int l1, int r1, int l2, int r2) {

--- a/library/trees/centroid_decomp.hpp
+++ b/library/trees/centroid_decomp.hpp
@@ -4,6 +4,7 @@
 //!   vector<basic_string<int>> g(n);
 //!   vector<int> p = cd(g, [&](int c) {});
 //! @endcode
+//! g is mutated (edges removed)
 //! @time O(n log n)
 //! @space O(n)
 vi cd(auto& g, auto f) {

--- a/library/trees/edge_cd.hpp
+++ b/library/trees/edge_cd.hpp
@@ -11,6 +11,7 @@
 //!   });
 //! @endcode
 //! handle single-edge-paths separately
+//! g is mutated (edges reordered/removed)
 //! @time O(n logφ n)
 //! @space O(n)
 template<class G> void edge_cd(vector<G>& g, auto f) {

--- a/library/trees/hld.hpp
+++ b/library/trees/hld.hpp
@@ -7,6 +7,7 @@
 //!   });
 //!   auto [l, r] = hld.subtree(u); // [l, r)
 //! @endcode
+//! g is mutated (parent edges removed)
 //! @time O(n + q log^2 n)
 //! @space O(n)
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/tests/.config/.cppcheck_suppression_list
+++ b/tests/.config/.cppcheck_suppression_list
@@ -14,7 +14,7 @@ arrayIndexOutOfBoundsCond:library_checker_aizu_tests/math/linear_prime_sieve.tes
 negativeContainerIndex:../library/strings/suffix_array/burrows_wheeler.hpp:50
 useStlAlgorithm:../kactl/content/numerical/FastFourierTransform.h:53
 useStlAlgorithm:../library/graphs/strongly_connected_components/add_edges_strongly_connected.hpp:58
-useStlAlgorithm:../library/math/matrix_related/row_reduce.hpp:28
+useStlAlgorithm:../library/math/matrix_related/row_reduce.hpp:29
 useStlAlgorithm:../library/math/count_paths/count_paths_triangle.hpp:25
 useStlAlgorithm:../library/math/matrix_related/xor_basis_unordered.hpp:14
 shadowFunction:../kactl/content/graph/BinaryLifting.h:17
@@ -35,7 +35,7 @@ syntaxError:../library/math/prime_sieve/calc_sieve.hpp:6
 syntaxError:../library/math/prime_sieve/calc_linear_sieve.hpp:6
 syntaxError:../library/loops/chooses.hpp:7
 syntaxError:../library/loops/quotients.hpp:10
-syntaxError:../library/loops/submasks.hpp:7
+syntaxError:../library/loops/submasks.hpp:8
 syntaxError:../library/loops/supermasks.hpp:8
 syntaxError:../library/math/prime_sieve/mobius.hpp:6
 syntaxError:../library/trees/lca_rmq/iterate_subtree.hpp:6


### PR DESCRIPTION
Full audit of every `@code` example, `@time`/`@space` claim, and semantic statement across all 136 library headers. Three parallel sweeps (data structures / math+graphs+convolution / trees+strings+monotonic_stack+dsu), each flagged item then hand-verified against the code before editing. Comment-only change; 0 code lines touched.

Fixes (6 files):

| File | Was | Now | Why |
|---|---|---|---|
| `data_structures_[l,r)/bit.hpp` | `walk2` returns min r s.t. sum of `[0,r]` >= sum | sum of `[0,r+1)` | closed-interval doc copied into the half-open directory; re-derived from code: walk2 returns r with prefix(r) < sum <= prefix(r+1). The `[l,r]` twin's doc is already correct for its convention |
| `graphs/min_vertex_cover.hpp` | `@time O(n + q * log n)`, `@space O(n * \alpha(n))` | `@time O(n + m)`, `@space O(n)` | cover() is one BFS pass over the matching graph; there are no queries and no DSU — the old claims were pasted from elsewhere |
| `strings/.../compare_substrings.hpp` | `if cmp1<0 ...` (x3) | `if cmp<0 ...` | example variable is `cmp`, not `cmp1` |
| `math/partitions.hpp` | "partitions of i numbers" | "partitions of i" | p[i] counts integer partitions of i (A000041), not partitions of an i-element set |
| `math/num_distinct_subsequences.hpp` | "subsquence" | "subsequence" | typo |
| `convolution/min_plus_convolution...hpp` | `res[k]` = min of `(a[i]+b[j])` | min of `(convex[j]+arbitrary[i])` | doc referenced params `a`,`b` that don't exist; index order matches the code (`convex[j]`, `arbitrary[i]`, `i+j==k`) |

Flagged by the sweeps but verified correct, so NOT changed:
- `dijkstra.hpp` `O(n + m log m)` — correct for lazy-deletion Dijkstra (heap holds up to m entries; O(m log m) = O(m log n))
- `mod_division.hpp` `O(log(y))` — Euclid on (y, mod) is O(log min(y, mod)) <= O(log y)
- `linear_lca.hpp` / `linear_kth_par.hpp` `O(n + q)` — queries are O(1) given O(1) hardware bit ops (bit_floor/bit_width), which is the standard model
- `derangements.hpp` indexing — dp[1]=0 falls out of zero-init; matches A000166
- `lcs_queries.hpp` `O(nm log m + q log m + q log q)` — the q log q term is real (per-row query sorts)
- monotonic_stack/cart tree/manacher/suffix array semantics — all exactly match code and tests

Validation:
- diff is 100% `//!` comment lines (checked mechanically)
- `clang-format-22 --dry-run --Werror --style=file:.config/dev.clang-format` passes on all 6 files
- all changed doc lines fit 59 columns
- affected tests compile: bit, bit_walk, hopcroft_karp (min_vertex_cover), min_plus_convolution, num_subsequences, partitions, lcp_query_zfunc (cmp_substrs)

Based on `doc-contracts` (#236) to avoid conflicts; if #236 merges first this rebases cleanly (no overlapping hunks).
