### PR TITLE
ci: restore incremental test verification (fetch-depth: 0)

### DIFF
--- a/.github/workflows/programming_team_code_ci.yml
+++ b/.github/workflows/programming_team_code_ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
     - name: Make preinstalled g++-14 the default g++


### PR DESCRIPTION
Restores incremental test verification in CI, which regressed in #234.

## Root cause

`oj-verify` (online-judge-verify-helper) only re-runs a test when the file's
git commit time is newer than the timestamp recorded in
`.verify-helper/timestamps.remote.json`. That comparison needs the repo's full
git history.

Before #234 the `library_checker_aizu` job used `actions/checkout@v1`, which
clones the **entire** history by default. #234 bumped it to
`actions/checkout@v4`, whose default is a **shallow** clone (`fetch-depth: 1`).
With only the HEAD commit present, `git log` reports every file as last
modified at HEAD — newer than every stored timestamp — so `oj-verify` re-runs
the whole suite on every push instead of just the changed files.

## Fix

Pin `fetch-depth: 0` on that job's checkout so `oj-verify` sees full history
again. This matches online-judge-verify-helper's own recommended Actions setup.

Only `library_checker_aizu` needs full history. The other jobs
(`update_main`, `publish_pdf`, the compile/lint jobs) don't read git history,
so they're left on the default shallow checkout.
