### PR TITLE
strings/trie: use array::fill instead of ranges::fill

### DIFF
--- a/strings/trie.hpp
+++ b/strings/trie.hpp
@@ -4,7 +4,7 @@ struct trie {
   struct node {
     array<int, 26> nxt;
     bool end_of_word = 0;
-    node() { ranges::fill(nxt, -1); }
+    node() { nxt.fill(-1); }
   };
   deque<node> t;
   trie(): t(1) {}


### PR DESCRIPTION
Replaces `ranges::fill(nxt, -1)` with `nxt.fill(-1)` in the trie node constructor.

Since `nxt` is a `std::array<int, 26>`, the member `.fill()` is behavior-identical, shorter, and avoids the `<algorithm>` ranges dependency.

Verified locally: compiles under `-std=c++20` and passes a basic insert/find sanity check.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author