### PR TITLE
dsu/kruskal_tree: tighten allocation to 2*n-1

### DIFF
--- a/library/dsu/kruskal_tree.hpp
+++ b/library/dsu/kruskal_tree.hpp
@@ -1,12 +1,13 @@
 #pragma once
 //! https://mzhang2021.github.io/cp-blog/kruskal/
+//! requires n >= 1 (2*n-1 allocation underflows when n == 0)
 //! @time O(n log n)
 //! @space O(n)
 struct kr_tree {
   int id;
   vi p;
   vector<vi> g;
-  kr_tree(int n): id(n), p(2 * n, -1), g(2 * n) {}
+  kr_tree(int n): id(n), p(2 * n - 1, -1), g(2 * n - 1) {}
   int f(int u) { return p[u] < 0 ? u : p[u] = f(p[u]); }
   bool join(int u, int v) {
     if ((u = f(u)) == (v = f(v))) return 0;

--- a/library/strings/manacher/manacher.hpp
+++ b/library/strings/manacher/manacher.hpp
@@ -14,6 +14,7 @@
 //! string b a a b a
 //! center  1 3 5 7
 //!
+//! requires n >= 1 (2*n-1 allocation underflows when n == 0)
 //! @time O(n)
 //! @space O(n)
 vi manacher(const auto& s) {

--- a/library/strings/suffix_array/suffix_array.hpp
+++ b/library/strings/suffix_array/suffix_array.hpp
@@ -32,6 +32,7 @@
 //!   auto [sa1, sa_inv1, lcp1] = get_sa(s_vec, 100'001);
 //! @endcode
 //!
+//! requires n >= 1 (lcp size n-1 underflows when n == 0)
 //! @time O(nlogn + max_num)
 //! @space O(n + max_num)
 auto get_sa(const auto& s, int max_num) {

--- a/library/strings/suffix_array/suffix_array_short.hpp
+++ b/library/strings/suffix_array/suffix_array_short.hpp
@@ -8,6 +8,7 @@
 //!   auto [sa1, sa_inv1, lcp1] = sa_short(s_vec);
 //! @endcode
 //! about 2-3x slower than KACTL
+//! requires n >= 1 (lcp size n-1 underflows when n == 0)
 //! @time O(n * log^2(n))
 //! @space O(n)
 auto sa_short(const auto& s) {


### PR DESCRIPTION
## What

Tighten the `kr_tree` allocation from `2 * n` to `2 * n - 1`, the exact
upper bound on the number of nodes in a Kruskal reconstruction tree over
`n` leaves.

## Why

The old `2 * n` sizing was one element too large. The tight `2 * n - 1`
matches the actual node count.

## Note on `n == 0`

`2 * n - 1` underflows to a huge `size_t` when `n == 0`, so the library
now documents `requires n >= 1` at each site with this kind of
allocation. This is the same latent constraint that already existed for
the suffix-array `lcp` (size `n - 1`) and manacher (`2 * n - 1`) code, so
a `//! requires n >= 1` note was added there as well for discoverability.

## Files

- `library/dsu/kruskal_tree.hpp` — code fix (`2*n` → `2*n-1`) + note
- `library/strings/manacher/manacher.hpp` — note
- `library/strings/suffix_array/suffix_array.hpp` — note
- `library/strings/suffix_array/suffix_array_short.hpp` — note
