### PR TITLE
prefer ranges algorithms over iterator-pair std calls (library + tests)

### DIFF
--- a/library/dsu/line_tree.hpp
+++ b/library/dsu/line_tree.hpp
@@ -20,7 +20,7 @@ struct line_tree {
   vi p, last;
   vector<pii> edge;
   line_tree(int n): p(n, -1), last(n), edge(n, {-1, -1}) {
-    iota(all(last), 0);
+    ranges::iota(last, 0);
   }
   int size(int u) { return -p[f(u)]; }
   int f(int u) { return p[u] < 0 ? u : p[u] = f(p[u]); }

--- a/library/graphs/mst.hpp
+++ b/library/graphs/mst.hpp
@@ -10,7 +10,7 @@
 pair<ll, vi> mst(const vector<array<int, 3>>& w_eds,
   int n) {
   vi order(sz(w_eds));
-  iota(all(order), 0);
+  ranges::iota(order, 0);
   ranges::sort(order, {},
     [&](int i) { return w_eds[i][2]; });
   DSU dsu(n);

--- a/library/graphs/strongly_connected_components/offline_incremental_scc.hpp
+++ b/library/graphs/strongly_connected_components/offline_incremental_scc.hpp
@@ -14,7 +14,7 @@ vi offline_incremental_scc(vector<array<int, 2>> eds,
   int n) {
   int m = sz(eds);
   vi ids(n, -1), joins(m, m), idx(m), vs(n), scc_id;
-  iota(all(idx), 0);
+  ranges::iota(idx, 0);
   vector<vi> g;
   auto dnc = [&](this auto&& dnc, auto el, auto er, int tl,
                int tr) {

--- a/library/graphs/uncommon/complement_graph_ccs.hpp
+++ b/library/graphs/uncommon/complement_graph_ccs.hpp
@@ -12,7 +12,7 @@
 vi get_complement_graph_ccs(const auto& g) {
   int n = sz(g);
   vi cc_id(n), unseen(n);
-  iota(all(unseen), 0);
+  ranges::iota(unseen, 0);
   vector<bool> is_g(n);
   for (int cnt = 0; !empty(unseen); cnt++) {
     int s = unseen.back();

--- a/library/math/prime_sieve/calc_linear_sieve.hpp
+++ b/library/math/prime_sieve/calc_linear_sieve.hpp
@@ -2,7 +2,7 @@
 //! @time O(mx)
 //! @space O(mx)
 vi primes, sieve(1001); //!< min prime factor
-iota(all(sieve), 0);
+ranges::iota(sieve, 0);
 rep(i, 2, sz(sieve)) {
   if (sieve[i] == i) primes.push_back(i);
   for (int prime : primes) {

--- a/library/math/prime_sieve/calc_sieve.hpp
+++ b/library/math/prime_sieve/calc_sieve.hpp
@@ -2,7 +2,7 @@
 //! @time O(mx * log(log mx))
 //! @space O(mx)
 vi sieve(1001); //!< min prime factor
-iota(all(sieve), 0);
+ranges::iota(sieve, 0);
 for (int i = 2; i * i < sz(sieve); i++)
   if (sieve[i] == i)
     for (int j = i * i; j < sz(sieve); j += i)

--- a/library/strings/longest_common_subsequence/lcs_dp.hpp
+++ b/library/strings/longest_common_subsequence/lcs_dp.hpp
@@ -10,7 +10,7 @@
 template<class T> struct lcs_dp {
   T t;
   vi dp;
-  lcs_dp(const T& t): t(t), dp(sz(t)) { iota(all(dp), 0); }
+  lcs_dp(const T& t): t(t), dp(sz(t)) { ranges::iota(dp, 0); }
   void push_onto_s(int c) {
     int v = -1;
     rep(i, 0, sz(t)) if (c == t[i] || dp[i] < v)

--- a/library/strings/manacher/longest_palindrome_query.hpp
+++ b/library/strings/manacher/longest_palindrome_query.hpp
@@ -11,7 +11,7 @@ struct longest_pal_query {
   //! @space O(n log n) for rmq, everything else is O(n)
   longest_pal_query(const auto& s): man(manacher(s)) {
     vi init(sz(man));
-    iota(all(init), 0);
+    ranges::iota(init, 0);
     rmq = {init, [&](int i1, int i2) {
              return len(i1) < len(i2) ? i2 : i1;
            }};

--- a/library/strings/suffix_array/suffix_array.hpp
+++ b/library/strings/suffix_array/suffix_array.hpp
@@ -37,10 +37,10 @@
 auto get_sa(const auto& s, int max_num) {
   int n = sz(s);
   vi sa(n), sa_inv(all(s)), lcp(n - 1);
-  iota(all(sa), 0);
+  ranges::iota(sa, 0);
   for (int i = 0; i < n; i = max(1, 2 * i)) {
     vi y(sa_inv), freq(max_num);
-    iota(all(sa_inv), n - i);
+    ranges::iota(sa_inv, n - i);
     ranges::copy_if(sa, begin(sa_inv) + i,
       [&](int& x) { return (x -= i) >= 0; });
     for (int x : y) freq[x]++;

--- a/library/strings/suffix_array/suffix_array_short.hpp
+++ b/library/strings/suffix_array/suffix_array_short.hpp
@@ -13,7 +13,7 @@
 auto sa_short(const auto& s) {
   int n = sz(s), b = 6;
   vi sa(n), sa_inv(all(s)), lcp(n - 1), t(n);
-  iota(all(sa), 0);
+  ranges::iota(sa, 0);
   for (int j = 1; j <= n; j *= b) {
     swap(t, sa_inv);
     auto cmp = [&](int i1, int i2) {

--- a/library/trees/edge_cd.hpp
+++ b/library/trees/edge_cd.hpp
@@ -30,10 +30,10 @@ template<class G> void edge_cd(vector<G>& g, auto f) {
     if (m < 2) return;
     u = ctd(u, u, m);
     int sum = 0;
-    auto it = partition(all(g[u]), [&](int v) {
+    auto it = begin(ranges::partition(g[u], [&](int v) {
       ll x = sum + s[v];
       return x * x < m * (m - x) ? sum = x : 0;
-    });
+    }));
     f(u, it - begin(g[u]));
     G oth(it, end(g[u]));
     g[u].erase(it, end(g[u]));

--- a/library/trees/extra_members/virtual_tree.hpp
+++ b/library/trees/extra_members/virtual_tree.hpp
@@ -16,7 +16,7 @@ array<vi, 2> compress_tree(vi subset) {
   rep(i, 1, len)
     subset.push_back(lca(subset[i - 1], subset[i]));
   ranges::sort(subset, {}, proj);
-  subset.erase(unique(all(subset)), end(subset));
+  subset.erase(begin(ranges::unique(subset)), end(subset));
   return {
     mono_st(subset,
       [&](int u, int v) { return in_subtree(u, v); }),


### PR DESCRIPTION
## What

Prefer the `ranges::` algorithms over their iterator-pair `std::`
counterparts for **full-range** calls, across both the library and the
test suite. The rule: use `ranges::` even when `all()` would work, unless
iterators specifically make more sense.

Conversions applied:

- `iota(all(x), v)` → `ranges::iota(x, v)`
- `unique(all(x))` → `begin(ranges::unique(x))` (erase / `== end` idioms)
- `partition(all(x), pred)` → `begin(ranges::partition(x, pred))`
- `remove_if(all(x), pred)` → `begin(ranges::remove_if(x, pred))` (erase)
- `next_permutation(all(x))` → `ranges::next_permutation(x).found`

`ranges::unique` / `ranges::partition` / `ranges::remove_if` return a
subrange, so `begin(...)` yields the iterator the erase / offset logic
needs; `ranges::next_permutation` returns a struct whose `.found` drives
the `do/while`.

## Why

- The library and tests already use `ranges::` algorithms extensively
  (e.g. `ranges::sort` everywhere); this makes the remaining full-range
  calls consistent with that style.
- Drops an `all(...)` macro expansion (relevant when expanding KACTL
  macros on `main`).

## Scope / what is intentionally NOT changed

- **`std::partial_sum`** and **`std::accumulate`** — no `ranges::`
  numeric-reduction equivalents in C++23 (`ranges::fold_left` would change
  the idiom), so these stay as-is.
- **Partial-range calls** (iterator sub-ranges such as
  `lower_bound(begin(sa) + lo, ...)`, `find_if(rank + begin(mat), ...)`,
  `partition(el, er, ...)`, `remove_if(idx + begin(upd_st), ...)`) — read
  more clearly with explicit iterators.
- **Member functions** named `find` / `count` — not `std::` algorithms.
- Scalar `std::min` / `std::max`.

## Files

**library/** (12 sites, 12 files): line_tree, mst,
offline_incremental_scc, complement_graph_ccs, calc_sieve,
calc_linear_sieve, lcs_dp, longest_palindrome_query, suffix_array (2),
suffix_array_short (iota); virtual_tree (unique); edge_cd (partition).

**tests/** (10 files): bit_ordered_set, kth_smallest_pst, mode_query,
sa_sort_pairs, seg_tree_find (unique); mono_st_asserts,
offline_incremental_scc, sa_sort_pairs (iota); permutation_tree_small,
rmq_small_n (iota + next_permutation); single_matching_bs (remove_if).

## Testing

Syntax-checked all affected library-checker/aizu tests locally with
`clang++ -std=c++2b -fsyntax-only` — all pass.

Behaviorally ran (exit 0, all asserts pass):
- `edge_cd_small_trees` — exhaustive over all trees on 2–7 nodes
  (`ranges::partition`).
- `lca_all_methods_aizu` — includes `compress_tree_asserts`, comparing
  `compress_tree` against KACTL's reference over random subsets plus the
  empty-subset edge case (`ranges::unique`).
- `permutation_tree_small` and `rmq_small_n` — exhaustive over all
  permutations of size 1–8 (`ranges::next_permutation(...).found`,
  `ranges::iota`).
